### PR TITLE
refactor:seedsを冪等化し、FlowItemとMessageCategoryの紐付けを保証する

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,12 +7,8 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
-puts "🌱 Seeding MessageCategories..."
 require_relative "seeds/message_categories"
-
-puts "🌱 Seeding FlowItems..."
-Dir[File.join(__dir__, "seeds/flow_items/*.rb")].sort.each do |file|
-  require file
-end
-
-puts "✅ Seeding completed"
+require_relative "seeds/flow_items_body"
+require_relative "seeds/flow_items_drink"
+require_relative "seeds/flow_items_request"
+require_relative "seeds/flow_items_feeling"

--- a/db/seeds/flow_items_body.rb
+++ b/db/seeds/flow_items_body.rb
@@ -1,35 +1,42 @@
-# flow_items are initial data for MVP.
-# Existing records are respected (no overwrite).
 body = MessageCategory.find_by!(key: "body")
 
-body.flow_items.find_or_create_by!(key: "hard") do |f|
-  f.name    = "苦しい"
-  f.kana     = "くるしい"
-  f.icon     = "sick"
-  f.icon_color    = "text-purple-500"
-  f.position = 1
-end
+items = [
+  {
+    key: "hard",
+    name: "苦しい",
+    kana: "くるしい",
+    icon: "sick",
+    icon_color: "text-purple-500",
+    position: 1
+  },
+  {
+    key: "pain",
+    name: "痛い",
+    kana: "いたい",
+    icon: "sentiment_very_dissatisfied",
+    icon_color: "text-red-600",
+    position: 2
+  },
+  {
+    key: "hot",
+    name: "暑い",
+    kana: "あつい",
+    icon: "wb_sunny",
+    icon_color: "text-orange-500",
+    position: 3
+  },
+  {
+    key: "cold",
+    name: "寒い",
+    kana: "さむい",
+    icon: "ac_unit",
+    icon_color: "text-cyan-600",
+    position: 4
+  }
+]
 
-body.flow_items.find_or_create_by!(key: "pain") do |f|
-  f.name    = "痛い"
-  f.kana     = "いたい"
-  f.icon     = "sentiment_very_dissatisfied"
-  f.icon_color    = "text-red-600"
-  f.position = 2
-end
-
-body.flow_items.find_or_create_by!(key: "hot") do |f|
-  f.name    = "暑い"
-  f.kana     = "あつい"
-  f.icon     = "wb_sunny"
-  f.icon_color    = "text-orange-500"
-  f.position = 3
-end
-
-body.flow_items.find_or_create_by!(key: "cold") do |f|
-  f.name    = "寒い"
-  f.kana     = "さむい"
-  f.icon     = "ac_unit"
-  f.icon_color    = "text-cyan-600"
-  f.position = 4
+items.each do |attrs|
+  item = body.flow_items.find_or_initialize_by(key: attrs[:key])
+  item.assign_attributes(attrs)
+  item.save!
 end

--- a/db/seeds/flow_items_drink.rb
+++ b/db/seeds/flow_items_drink.rb
@@ -1,41 +1,50 @@
 drink = MessageCategory.find_by!(key: "drink")
 
-drink.flow_items.find_or_create_by!(key: "water") do |f|
-  f.name       = "水"
-  f.kana       = "みず"
-  f.icon       = "water_drop"
-  f.icon_color = "text-cyan-500"
-  f.position   = 1
-end
+items = [
+  {
+    key: "water",
+    name: "水",
+    kana: "みず",
+    icon: "water_drop",
+    icon_color: "text-cyan-500",
+    position: 1
+  },
+  {
+    key: "sports_drink",
+    name: "スポーツドリンク",
+    kana: "すぽーつどりんく",
+    icon: "water",
+    icon_color: "text-blue-600",
+    position: 2
+  },
+  {
+    key: "tea",
+    name: "お茶",
+    kana: "おちゃ",
+    icon: "emoji_food_beverage",
+    icon_color: "text-green-600",
+    position: 3
+  },
+  {
+    key: "carbonated_drink",
+    name: "炭酸飲料",
+    kana: "たんさんいんりょう",
+    icon: "local_drink",
+    icon_color: "text-yellow-500",
+    position: 4
+  },
+  {
+    key: "fruit_juice",
+    name: "フルーツジュース",
+    kana: "ふるーつじゅーす",
+    icon: "grocery",
+    icon_color: "text-orange-500",
+    position: 5
+  }
+]
 
-drink.flow_items.find_or_create_by!(key: "sports_drink") do |f|
-  f.name       = "スポーツドリンク"
-  f.kana       = "すぽーつどりんく"
-  f.icon       = "water"
-  f.icon_color = "text-blue-600"
-  f.position   = 2
-end
-
-drink.flow_items.find_or_create_by!(key: "tea") do |f|
-  f.name       = "お茶"
-  f.kana       = "おちゃ"
-  f.icon       = "emoji_food_beverage"
-  f.icon_color = "text-green-600"
-  f.position   = 3
-end
-
-drink.flow_items.find_or_create_by!(key: "carbonated_drink") do |f|
-  f.name       = "炭酸飲料"
-  f.kana       = "たんさんいんりょう"
-  f.icon       = "local_drink"
-  f.icon_color = "text-yellow-500"
-  f.position   = 4
-end
-
-drink.flow_items.find_or_create_by!(key: "fruit_juice") do |f|
-  f.name       = "フルーツジュース"
-  f.kana       = "ふるーつじゅーす"
-  f.icon       = "grocery"
-  f.icon_color = "text-orange-500"
-  f.position   = 5
+items.each do |attrs|
+  item = drink.flow_items.find_or_initialize_by(key: attrs[:key])
+  item.assign_attributes(attrs)
+  item.save!
 end

--- a/db/seeds/flow_items_feeling.rb
+++ b/db/seeds/flow_items_feeling.rb
@@ -1,33 +1,42 @@
 feeling = MessageCategory.find_by!(key: "feeling")
 
-feeling.flow_items.find_or_create_by!(key: "happy") do |f|
-  f.name       = "うれしい"
-  f.kana       = "うれしい"
-  f.icon       = "sentiment_excited"
-  f.icon_color = "text-amber-500"
-  f.position   = 1
-end
+items = [
+  {
+    key: "happy",
+    name: "うれしい",
+    kana: "うれしい",
+    icon: "sentiment_excited",
+    icon_color: "text-amber-500",
+    position: 1
+  },
+  {
+    key: "lonely",
+    name: "さみしい",
+    kana: "さみしい",
+    icon: "sentiment_dissatisfied",
+    icon_color: "text-blue-400",
+    position: 2
+  },
+  {
+    key: "anxious",
+    name: "不安",
+    kana: "ふあん",
+    icon: "sentiment_worried",
+    icon_color: "text-purple-500",
+    position: 3
+  },
+  {
+    key: "okay",
+    name: "大丈夫",
+    kana: "だいじょうぶ",
+    icon: "thumb_up",
+    icon_color: "text-emerald-500",
+    position: 4
+  }
+]
 
-feeling.flow_items.find_or_create_by!(key: "lonely") do |f|
-  f.name       = "さみしい"
-  f.kana       = "さみしい"
-  f.icon       = "sentiment_dissatisfied"
-  f.icon_color = "text-blue-400"
-  f.position   = 2
-end
-
-feeling.flow_items.find_or_create_by!(key: "anxious") do |f|
-  f.name       = "不安"
-  f.kana       = "ふあん"
-  f.icon       = "sentiment_worried"
-  f.icon_color = "text-purple-500"
-  f.position   = 3
-end
-
-feeling.flow_items.find_or_create_by!(key: "okay") do |f|
-  f.name       = "大丈夫"
-  f.kana       = "だいじょうぶ"
-  f.icon       = "thumb_up"
-  f.icon_color = "text-emerald-500"
-  f.position   = 4
+items.each do |attrs|
+  item = feeling.flow_items.find_or_initialize_by(key: attrs[:key])
+  item.assign_attributes(attrs)
+  item.save!
 end

--- a/db/seeds/flow_items_request.rb
+++ b/db/seeds/flow_items_request.rb
@@ -1,33 +1,42 @@
 request = MessageCategory.find_by!(key: "request")
 
-request.flow_items.find_or_create_by!(key: "toilet") do |f|
-  f.name       = "トイレ"
-  f.kana       = "といれ"
-  f.icon       = "wc"
-  f.icon_color = "text-cyan-600"
-  f.position   = 1
-end
+items = [
+  {
+    key: "toilet",
+    name: "トイレ",
+    kana: "といれ",
+    icon: "wc",
+    icon_color: "text-cyan-600",
+    position: 1
+  },
+  {
+    key: "temperature",
+    name: "温度",
+    kana: "おんど",
+    icon: "thermostat",
+    icon_color: "text-emerald-500",
+    position: 2
+  },
+  {
+    key: "light",
+    name: "明かり",
+    kana: "あかり",
+    icon: "lightbulb",
+    icon_color: "text-amber-500",
+    position: 3
+  },
+  {
+    key: "bed",
+    name: "ベッド",
+    kana: "べっど",
+    icon: "bed",
+    icon_color: "text-indigo-500",
+    position: 4
+  }
+]
 
-request.flow_items.find_or_create_by!(key: "temperature") do |f|
-  f.name       = "温度"
-  f.kana       = "おんど"
-  f.icon       = "thermostat"
-  f.icon_color = "text-emerald-600"
-  f.position   = 2
-end
-
-request.flow_items.find_or_create_by!(key: "light") do |f|
-  f.name       = "明かり"
-  f.kana       = "あかり"
-  f.icon       = "lightbulb"
-  f.icon_color = "text-amber-500"
-  f.position   = 3
-end
-
-request.flow_items.find_or_create_by!(key: "bed") do |f|
-  f.name       = "ベッド"
-  f.kana       = "べっど"
-  f.icon       = "bed"
-  f.icon_color = "text-indigo-500"
-  f.position   = 4
+items.each do |attrs|
+  item = request.flow_items.find_or_initialize_by(key: attrs[:key])
+  item.assign_attributes(attrs)
+  item.save!
 end


### PR DESCRIPTION
## 概要
初期データ投入用の seeds を整理・リファクタリングし、FlowItem と MessageCategory の紐付けが常に保証されるように修正しました。
本番環境で `flow_items.message_category_id` が NULL になり、カテゴリ配下の項目が表示されない問題への対応です。

## 変更内容
- MessageCategory / FlowItemのseedsを冪等に再設計
- `find_or_initialize_by + assign_attributes` を用いて、既存レコードがある場合でも関連付けが補正されるように修正
- FlowItemのseeds をカテゴリ単位のファイルに分割し、責務を明確化
- seeds.rbから各seedファイルを明示的に require する構成に整理

## 確認事項
- 開発環境で `rails db:seed` を複数回実行してもデータが重複しないこと
- 各 MessageCategory 配下に正しい FlowItem が紐づいていること
