### PR TITLE
本番DB差分により失敗していたmessage_logsのmigration を修正

### DIFF
--- a/db/migrate/20260130015846_remove_names_from_message_logs.rb
+++ b/db/migrate/20260130015846_remove_names_from_message_logs.rb
@@ -1,6 +1,6 @@
 class RemoveNamesFromMessageLogs < ActiveRecord::Migration[7.2]
   def change
-    remove_column :message_logs, :message_category_name, :string
-    remove_column :message_logs, :flow_item_name, :string
+    remove_column :message_logs, :message_category_name if column_exists?(:message_logs, :message_category_name)
+    remove_column :message_logs, :flow_item_name if column_exists?(:message_logs, :flow_item_name)
   end
 end


### PR DESCRIPTION
## 概要
本番環境のDB状態と乖離したmigrationが原因で、デプロイ時に `PG::UndefinedColumn` エラーが発生していたため修正しました。

## 背景
- `message_logs` テーブルに存在しないカラム (`message_category_name` など) を削除しようとする migration があり、
  本番環境で `db:migrate` が失敗していました。
- 開発環境では過去に存在していたカラムであったため、差分に気づきにくい状態でした。

## 対応内容
- 本番DBに存在しないカラムを対象としていたmigrationを修正
- 本番・開発環境で migration が安全に実行できる状態に調整

## 影響範囲
- 既存データへの影響なし
- テーブル構造の破壊的変更なし
- アプリの挙動変更なし（migration エラー解消のみ）
