### PR TITLE
メッセージカテゴリ作成時に key を自動生成するよう修正

### DIFF
--- a/app/models/message_category.rb
+++ b/app/models/message_category.rb
@@ -5,6 +5,8 @@ class MessageCategory < ApplicationRecord
   validates :name, uniqueness: { scope: :user_id }
   validates :key, presence: true, uniqueness: true
 
+  before_validation :set_key, on: :create
+
   scope :for_user, ->(user) {
     if user
       where(user_id: [ nil, user.id ])
@@ -19,5 +21,11 @@ class MessageCategory < ApplicationRecord
 
   def ruby
     kana
+  end
+
+  private
+
+  def set_key
+    self.key ||= SecureRandom.uuid
   end
 end


### PR DESCRIPTION
## 概要
メッセージカテゴリ追加時に、UI上で入力できないkeyが必須バリデーションとなっており、カテゴリを追加できない不具合が発生していたため修正しました。

## 対応内容
- MessageCategoryにbefore_validationを追加
- カテゴリ作成時にkeyを自動生成するように変更
- UI（name / kana / icon）とモデルバリデーションの不整合を解消

## 動作確認
- ログイン状態でカテゴリを新規作成できることを確認
- 作成後、カテゴリ一覧に正常に表示されることを確認
