### PR TITLE
GA4導入およびTurbo対応ページビュー計測の実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,13 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener("turbo:load", () => {
+  if (window.gtag) {
+    window.gtag("event", "page_view", {
+      page_path: window.location.pathname,
+      page_location: window.location.href,
+      page_title: document.title
+    });
+  }
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,20 @@
 
     <%= yield :head %>
 
+    <% if Rails.env.production? && ENV["GA_MEASUREMENT_ID"].present? %>
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GA_MEASUREMENT_ID"] %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '<%= ENV["GA_MEASUREMENT_ID"] %>', {
+          send_page_view: false
+        });
+      </script>
+    <% end %>
+
     <!-- Material Symbols（追加） -->
     <link
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"


### PR DESCRIPTION
## 概要
- MabaTalkにGA4(Google Analytics)を導入しました。
- 本番環境においてページビューおよびTurbo遷移時のURL変更を正しく計測できるようにし、今後の利用状況分析・改善施策のための基盤を整備しました。
- 開発環境では計測が動作しないよう、安全な設計としています。

## 背景
- アプリ利用状況の可視化
- 離脱ポイントの把握
- フロー完了率の分析基盤構築

## 実装内容
- GA4のMeasurement IDを環境変数（GA_MEASUREMENT_ID）で管理
- production環境のみでタグを読み込む条件分岐を追加
- `send_page_view: false` を設定し、自動ページビュー送信を無効化
- `turbo:load` イベントで手動 `page_view` を送信する実装を追加
  - SPA的遷移でもURLごとに正しく計測されるよう対応
- 既存アプリ動作に影響がないことを確認

## 動作確認
- 本番環境のみでGAタグが読み込まれる
- Turbo遷移ごとにリアルタイムレポートへ反映される
- コンソールエラーが発生していないこと