### PR TITLE
設定・認証関連の導線を整理し、設定画面をハブとして実装

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,0 +1,8 @@
+class FeedbacksController < ApplicationController
+  def new
+  end
+
+  def create
+    redirect_to settings_path, notice: "送信ありがとうございました！"
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
-# app/controllers/pages_controller.rb
 class PagesController < ApplicationController
-  def home
-  end
+  def home; end
+  def guide; end
+  def terms; end
+  def privacy_policy; end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,6 @@
+class SettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+  end
+end

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -1,0 +1,2 @@
+module FeedbacksHelper
+end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,2 @@
+module SettingsHelper
+end

--- a/app/views/feedbacks/create.html.erb
+++ b/app/views/feedbacks/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Feedbacks#create</h1>
+<p>Find me in app/views/feedbacks/create.html.erb</p>

--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title do %>
+  ご意見箱
+<% end %>
+
+<main class="relative min-h-screen w-full bg-stone-200 overflow-x-hidden pb-24">
+  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md mx-auto">
+    <div class="w-full bg-white/90 rounded-2xl p-6 shadow border border-stone-100">
+      <p class="text-sm text-stone-600 mb-4">
+        困ったこと・改善してほしいことを送れます。
+      </p>
+
+      <%= form_with url: feedbacks_path, method: :post, data: { turbo: true } do |f| %>
+        <div class="mb-4">
+          <%= f.label :message, "内容", class: "block text-sm font-bold text-stone-700 mb-2" %>
+          <%= f.text_area :message, rows: 6,
+            class: "w-full rounded-xl border border-stone-300 p-3",
+            placeholder: "例）ボタンが押しづらい / こうしてほしい など" %>
+        </div>
+
+        <%= f.submit "送信する",
+          class: "w-full h-12 rounded-2xl bg-amber-600 text-white font-bold hover:bg-amber-700 active:scale-[0.98] transition" %>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title do %>
+  使い方ガイド
+<% end %>
+
+<main class="min-h-screen bg-stone-200 px-4 py-8">
+  <div class="max-w-md mx-auto bg-white rounded-2xl shadow p-6 space-y-4">
+    <h1 class="text-xl font-bold text-stone-900">
+      MabaTalkの使い方
+    </h1>
+
+    <p class="text-stone-700 leading-relaxed">
+      1. メッセージカテゴリを表示します。<br>
+      2. 順番に指差しで問いかけます。<br>
+      3. まばたきで意思を確認します。
+    </p>
+
+    <p class="text-sm text-stone-600">
+      ※詳しい説明は今後追加予定です。
+    </p>
+  </div>
+</main>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title do %>
+  プライバシーポリシー
+<% end %>
+
+<main class="min-h-screen bg-stone-200 px-4 py-8">
+  <div class="max-w-md mx-auto bg-white rounded-2xl shadow p-6 space-y-4">
+    <h1 class="text-xl font-bold text-stone-900">
+      プライバシーポリシー
+    </h1>
+
+    <p class="text-stone-700 text-sm leading-relaxed">
+      本サービスでは、ログイン情報および
+      利用履歴を適切に管理します。
+      取得した情報は第三者へ提供しません。
+    </p>
+  </div>
+</main>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  利用規約
+<% end %>
+
+<main class="min-h-screen bg-stone-200 px-4 py-8">
+  <div class="max-w-md mx-auto bg-white rounded-2xl shadow p-6 space-y-4">
+    <h1 class="text-xl font-bold text-stone-900">
+      利用規約
+    </h1>
+
+    <p class="text-stone-700 text-sm leading-relaxed">
+      本サービスは、介護者と要介護者の
+      コミュニケーションを支援する目的で提供されています。
+      本サービスの利用により生じた損害について、
+      開発者は責任を負いません。
+    </p>
+  </div>
+</main>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,0 +1,244 @@
+<% content_for :page_title do %>
+  設定
+<% end %>
+
+<main class="relative min-h-screen w-full bg-stone-200 overflow-x-hidden pb-24">
+  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md mx-auto space-y-6">
+
+    <%# =========================
+        はじめての方へ（安心導線）
+        ========================= %>
+    <section class="w-full">
+      <div class="flex items-center gap-2 mb-3 px-2">
+        <span class="material-symbols-outlined text-amber-700">menu_book</span>
+        <h3 class="text-lg font-bold text-stone-800">はじめての方へ</h3>
+      </div>
+
+      <div class="bg-white/90 backdrop-blur rounded-2xl shadow border border-stone-100 overflow-hidden">
+        <%= link_to guide_path,
+                    class: "w-full flex items-center gap-3 p-5 hover:bg-stone-100/60 active:scale-[0.99] transition focus:outline-none focus:ring-4 focus:ring-stone-300" do %>
+
+          <div class="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+            <span class="material-symbols-outlined text-amber-700 text-[26px]">
+              touch_app
+            </span>
+          </div>
+
+          <div class="flex-1 text-left">
+            <div class="text-[18px] font-bold text-stone-900 leading-tight">
+              使い方を見る
+            </div>
+            <div class="text-sm text-stone-600 mt-1 leading-relaxed">
+              基本操作を図解で確認できます
+            </div>
+          </div>
+
+          <span class="material-symbols-outlined text-stone-400">
+            chevron_right
+          </span>
+        <% end %>
+    </section>
+
+    <%# =========================
+        お困りですか？
+        ========================= %>
+    <section class="w-full">
+      <div class="flex items-center gap-2 mb-3 px-2">
+        <span class="material-symbols-outlined text-sky-500">support_agent</span>
+        <h3 class="text-lg font-bold text-stone-800">お困りですか？</h3>
+      </div>
+
+      <div class="bg-white/90 backdrop-blur rounded-2xl shadow border border-stone-100 overflow-hidden">
+        <%= link_to new_feedback_path,
+                    class: "w-full flex items-center gap-3 p-5 hover:bg-stone-100/60 active:scale-[0.99] transition focus:outline-none focus:ring-4 focus:ring-stone-300" do %>
+
+          <div class="w-12 h-12 rounded-full bg-sky-100 flex items-center justify-center shrink-0">
+            <span class="material-symbols-outlined text-sky-500 text-[26px]">
+              chat
+            </span>
+          </div>
+
+          <div class="flex-1 text-left">
+            <div class="text-[18px] font-bold text-stone-900 leading-tight">
+              ご意見箱
+            </div>
+            <div class="text-sm text-stone-600 mt-1 leading-relaxed">
+              改善のために、困ったことを送れます
+            </div>
+          </div>
+
+          <span class="material-symbols-outlined text-stone-400">
+            chevron_right
+          </span>
+
+        <% end %>
+
+      </div>
+
+    </section>
+
+    <%# =========================
+        アカウント（Devise既存機能へ誘導）
+        ========================= %>
+    <section class="w-full">
+      <div class="flex items-center gap-2 mb-3 px-2">
+        <span class="material-symbols-outlined text-amber-700">manage_accounts</span>
+        <h3 class="text-lg font-bold text-stone-800">アカウント</h3>
+      </div>
+
+      <div class="bg-white/90 backdrop-blur rounded-2xl shadow border border-stone-100 overflow-hidden divide-y divide-stone-100">
+
+        <%# プロフィール編集（= Devise registration edit に寄せる） %>
+        <%= link_to edit_user_registration_path,
+          class: "
+            w-full flex items-center gap-3 p-5
+            hover:bg-stone-100/60 active:scale-[0.99] transition
+            focus:outline-none focus:ring-4 focus:ring-stone-300
+          " do %>
+          <div class="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+            <span class="material-symbols-outlined text-amber-700 text-[26px]">person</span>
+          </div>
+          <div class="flex-1 text-left">
+            <div class="text-[18px] font-bold text-stone-900 leading-tight">プロフィール編集</div>
+            <div class="text-sm text-stone-600 mt-1 leading-relaxed">名前・メールなどを変更します</div>
+          </div>
+          <span class="material-symbols-outlined text-stone-400">chevron_right</span>
+        <% end %>
+
+        <%# メールアドレス（同じく Devise edit へ。UI文言で“メール”に焦点） %>
+        <%= link_to edit_user_registration_path(anchor: "email"),
+          class: "
+            w-full flex items-center gap-3 p-5
+            hover:bg-stone-100/60 active:scale-[0.99] transition
+            focus:outline-none focus:ring-4 focus:ring-stone-300
+          " do %>
+          <div class="w-12 h-12 rounded-full bg-orange-100 flex items-center justify-center shrink-0">
+            <span class="material-symbols-outlined text-orange-600 text-[26px]">mail</span>
+          </div>
+          <div class="flex-1 text-left">
+            <div class="text-[18px] font-bold text-stone-900 leading-tight">メールアドレス</div>
+            <div class="text-sm text-stone-600 mt-1 leading-relaxed">ログインに使うメールを変更します</div>
+          </div>
+          <span class="material-symbols-outlined text-stone-400">chevron_right</span>
+        <% end %>
+
+        <%# パスワード（同じく Devise edit へ。UI文言で“パスワード”に焦点） %>
+        <%= link_to edit_user_registration_path(anchor: "password"),
+          class: "
+            w-full flex items-center gap-3 p-5
+            hover:bg-stone-100/60 active:scale-[0.99] transition
+            focus:outline-none focus:ring-4 focus:ring-stone-300
+          " do %>
+          <div class="w-12 h-12 rounded-full bg-indigo-100 flex items-center justify-center shrink-0">
+            <span class="material-symbols-outlined text-indigo-600 text-[26px]">lock</span>
+          </div>
+          <div class="flex-1 text-left">
+            <div class="text-[18px] font-bold text-stone-900 leading-tight">パスワード設定</div>
+            <div class="text-sm text-stone-600 mt-1 leading-relaxed">安全のために定期的に変更できます</div>
+          </div>
+          <span class="material-symbols-outlined text-stone-400">chevron_right</span>
+        <% end %>
+
+        <%# ログアウト（誤操作を防ぐため“赤すぎない”がコツ） %>
+        <div class="p-5">
+          <%= button_to destroy_user_session_path,
+            method: :delete,
+            form: { data: { turbo: true } },
+            class: "
+              w-full h-14
+              flex items-center justify-center gap-2
+              rounded-2xl
+              bg-stone-100/80 hover:bg-stone-200
+              text-stone-700 font-bold
+              active:scale-[0.99] transition
+              focus:outline-none focus:ring-4 focus:ring-stone-300
+            " do %>
+            <span class="material-symbols-outlined text-[22px]">logout</span>
+            ログアウト
+          <% end %>
+        </div>
+      </div>
+
+      <%# 補足: anchor は“将来 Devise 編集画面を整える時”に使える程度の目印です。
+          今すぐ section 分割する必要はありません（情報設計のハブの役割が優先）。
+      %>
+    </section>
+
+    <%# =========================
+        サービスについて
+        ========================= %>
+    <section class="w-full">
+      <div class="flex items-center gap-2 mb-3 px-2">
+        <span class="material-symbols-outlined text-stone-600">info</span>
+        <h3 class="text-lg font-bold text-stone-800">サービスについて</h3>
+      </div>
+
+      <div class="bg-white/90 backdrop-blur rounded-2xl shadow border border-stone-100 overflow-hidden divide-y divide-stone-100">
+        <%= link_to "https://note.com/prime_snail5740/n/n02d9f797d46a",
+              target: "_blank",
+              rel: "noopener",
+              class: "w-full flex items-center gap-3 p-5 hover:bg-stone-100/60 active:scale-[0.99] transition focus:outline-none focus:ring-4 focus:ring-stone-300" do %>
+
+          <div class="w-12 h-12 rounded-full bg-stone-100 flex items-center justify-center shrink-0">
+            <span class="material-symbols-outlined text-stone-600 text-[26px]">
+              description
+            </span>
+          </div>
+
+          <div class="flex-1 text-left">
+            <div class="text-[18px] font-bold text-stone-900 leading-tight">
+              MabaTalk公式note
+            </div>
+            <div class="text-sm text-stone-600 mt-1 leading-relaxed">
+              開発背景やアップデート情報
+            </div>
+          </div>
+
+          <span class="material-symbols-outlined text-stone-400">
+            open_in_new
+          </span>
+        <% end %>
+
+        <%= link_to terms_path,
+              class: "w-full flex items-center justify-between p-5 hover:bg-stone-100/60 active:scale-[0.99] transition focus:outline-none focus:ring-4 focus:ring-stone-300" do %>
+          <span class="text-[18px] font-bold text-stone-900">利用規約</span>
+          <span class="material-symbols-outlined text-stone-400">chevron_right</span>
+        <% end %>
+
+        <%= link_to privacy_policy_path,
+              class: "w-full flex items-center justify-between p-5 hover:bg-stone-100/60 active:scale-[0.99] transition focus:outline-none focus:ring-4 focus:ring-stone-300" do %>
+          <span class="text-[18px] font-bold text-stone-900">プライバシーポリシー</span>
+          <span class="material-symbols-outlined text-stone-400">chevron_right</span>
+        <% end %>
+      </div>
+
+      <%# TODO:
+          - mabatalk_note_url は credentials / ENV に置くのがおすすめ
+          - terms_path, privacy_policy_path が無い場合は PagesController などで静的ページを作る
+      %>
+    </section>
+
+    <%# =========================
+        アカウント削除（最下部 + 目立たせすぎない）
+        ========================= %>
+    <section class="w-full pt-4">
+      <div class="flex justify-center">
+        <%= button_to user_registration_path,
+          method: :delete,
+          form: { data: { turbo: true } },
+          data: {
+            turbo_confirm: "アカウントを削除します。\n履歴などのデータは元に戻せません。\n本当に削除しますか？"
+          },
+          class: "
+            text-sm text-stone-500 hover:text-red-600
+            underline underline-offset-4 decoration-stone-300
+            px-4 py-2 rounded-full
+            transition
+          " do %>
+          アカウントを削除する
+        <% end %>
+      </div>
+    </section>
+
+  </div>
+</main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -54,7 +54,7 @@
     <% end %>
 
     <!-- 設定（未実装） -->
-    <%= link_to "#",
+    <%= link_to settings_path,
       class: "flex flex-col items-center gap-1 min-w-[64px]" do %>
 
       <span class="material-symbols-outlined text-stone-400">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "feedbacks/new"
+  get "feedbacks/create"
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 
   root to: "homes#top"
@@ -12,6 +14,14 @@ Rails.application.routes.draw do
   resources :message_logs, only: %i[index create]
 
   resource :message_completion, only: %i[show]
+
+  resource :settings, only: %i[show]
+
+  get "/guide", to: "pages#guide", as: :guide
+  get "/terms", to: "pages#terms", as: :terms
+  get "/privacy_policy", to: "pages#privacy_policy", as: :privacy_policy
+
+  resources :feedbacks, only: %i[new create]
 
   # --- 以下はRails標準の補助機能 ---
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class FeedbacksControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get feedbacks_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get feedbacks_create_url
+    assert_response :success
+  end
+end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SettingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get settings_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
- 設定・認証関連の機能が分散していたため、設定画面をハブとして導線を整理しました。
- 本PRでは新機能の追加は行わず、既存機能・静的ページへの遷移整備を目的としています。

---

## 実装内容

### 1. 設定画面の実装
- フッターの「設定」から遷移可能に変更
- 設定画面をハブとして各機能へ導線を整理

### 2. 認証関連導線の整理
- プロフィール編集（Devise edit）
- メールアドレス変更
- パスワード変更
- ログアウト
- アカウント削除

### 3. 静的ページ導線
- 使い方（guide）
- 利用規約
- プライバシーポリシー

### 4. ご意見箱導線の追加
- 設定画面から `/feedbacks/new` へ遷移可能に
- 送信後は設定画面へリダイレクト
- 今回は保存処理は未実装（導線のみ）

---

## 動作確認

- [x] フッターの「設定」から設定画面へ遷移できる
- [x] 設定画面から各リンクへ遷移できる
- [x] ご意見箱ページが表示される
- [x] 送信後にエラーなく設定画面へ戻る
- [x] ログアウト・アカウント削除が正常動作する