### PR TITLE
ご意見箱ページに準備中の文言追加

### DIFF
--- a/app/views/feedbacks/new.html.erb
+++ b/app/views/feedbacks/new.html.erb
@@ -3,23 +3,37 @@
 <% end %>
 
 <main class="relative min-h-screen w-full bg-stone-200 overflow-x-hidden pb-24">
-  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md mx-auto">
-    <div class="w-full bg-white/90 rounded-2xl p-6 shadow border border-stone-100">
-      <p class="text-sm text-stone-600 mb-4">
-        困ったこと・改善してほしいことを送れます。
+  <div class="flex flex-col items-center px-4 pt-10 w-full max-w-md mx-auto">
+
+    <div class="w-full bg-white/90 backdrop-blur rounded-2xl shadow border border-stone-100 p-8 text-center space-y-6">
+
+      <div class="flex justify-center">
+        <span class="material-symbols-outlined text-sky-500 text-[48px]">
+          chat
+        </span>
+      </div>
+
+      <h2 class="text-xl font-bold text-stone-800">
+        ご意見箱（準備中）
+      </h2>
+
+      <p class="text-stone-600 leading-relaxed text-sm">
+        現在、ご意見の送信機能は準備中です。<br>
+        より良いサービスにするための仕組みを整えています。
       </p>
 
-      <%= form_with url: feedbacks_path, method: :post, data: { turbo: true } do |f| %>
-        <div class="mb-4">
-          <%= f.label :message, "内容", class: "block text-sm font-bold text-stone-700 mb-2" %>
-          <%= f.text_area :message, rows: 6,
-            class: "w-full rounded-xl border border-stone-300 p-3",
-            placeholder: "例）ボタンが押しづらい / こうしてほしい など" %>
-        </div>
+      <p class="text-stone-500 text-xs">
+        近日中に公開予定です。
+      </p>
 
-        <%= f.submit "送信する",
-          class: "w-full h-12 rounded-2xl bg-amber-600 text-white font-bold hover:bg-amber-700 active:scale-[0.98] transition" %>
-      <% end %>
+      <div class="pt-6">
+        <%= link_to settings_path,
+          class: "inline-block px-6 py-3 rounded-full bg-stone-800 text-white text-sm font-bold hover:bg-stone-700 transition" do %>
+          設定へ戻る
+        <% end %>
+      </div>
+
     </div>
+
   </div>
 </main>


### PR DESCRIPTION
## 概要
設定画面をハブとして導線を整理したが、ご意見箱ページが送信できるような文言だっため、準備中に修正

## 実装内容
- 現在は「準備中」画面として実装
- 送信機能は未実装（今後別Issueで対応予定）
