### PR TITLE
使い方ガイドページを実装し、UI・説明文・SVGイラストを整備

### DIFF
--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -2,20 +2,321 @@
   使い方ガイド
 <% end %>
 
-<main class="min-h-screen bg-stone-200 px-4 py-8">
-  <div class="max-w-md mx-auto bg-white rounded-2xl shadow p-6 space-y-4">
-    <h1 class="text-xl font-bold text-stone-900">
-      MabaTalkの使い方
-    </h1>
+<main class="relative flex min-h-screen w-full flex-col bg-stone-200 overflow-x-hidden pb-24">
+  <div class="flex flex-col items-center px-4 pt-8 w-full max-w-md mx-auto">
 
-    <p class="text-stone-700 leading-relaxed">
-      1. メッセージカテゴリを表示します。<br>
-      2. 順番に指差しで問いかけます。<br>
-      3. まばたきで意思を確認します。
-    </p>
+    <!-- Hero -->
+    <section class="w-full mb-10 text-center">
+      <p class="text-sm font-bold tracking-wide text-stone-500">
+        まばたきでつながる
+      </p>
 
-    <p class="text-sm text-stone-600">
-      ※詳しい説明は今後追加予定です。
-    </p>
+      <h1 class="text-3xl font-black tracking-tight text-amber-700">
+        使い方ガイド
+      </h1>
+    </section>
+
+    <!-- Steps -->
+    <section class="w-full mb-12">
+      <div class="flex items-center gap-2 mb-6 px-2">
+        <span class="material-symbols-outlined text-amber-700">touch_app</span>
+        <h3 class="text-lg font-bold text-stone-800">基本の3ステップ</h3>
+      </div>
+
+      <div class="flex flex-col gap-8 relative">
+        <div class="absolute left-[19px] top-6 bottom-6 w-0.5 bg-stone-300 -z-0"></div>
+
+        <!-- STEP 1 -->
+        <div class="relative flex items-start gap-4 z-10">
+
+          <div class="flex items-center justify-center w-10 h-10 rounded-full bg-white border-2 border-amber-600 text-amber-700 font-bold text-lg shadow-sm shrink-0">
+            1
+          </div>
+
+          <div class="flex-1 bg-white p-5 rounded-2xl shadow-sm space-y-4">
+
+            <h4 class="font-bold text-stone-800">メッセージカテゴリを見せる</h4>
+
+            <div class="aspect-video bg-stone-100 rounded-xl flex items-center justify-center">
+              <svg viewBox="0 0 260 160" class="w-56">
+
+                <!-- ベッド -->
+                <rect x="20" y="110" width="180" height="10" fill="#d6d3d1"/>
+                <rect x="20" y="100" width="30" height="20" fill="#e7e5e4"/>
+
+                <!-- 本人（上半身起こし） -->
+                <circle cx="90" cy="75" r="18" fill="#a8a29e"/>
+                <rect x="75" y="90" width="30" height="25" fill="#a8a29e"/>
+
+                <!-- 介護者 -->
+                <circle cx="200" cy="60" r="16" fill="#f59e0b"/>
+                <rect x="190" y="75" width="20" height="30" fill="#f59e0b"/>
+
+                <!-- スマホ -->
+                <rect x="170" y="75" width="25" height="45" rx="6" fill="#1f2937"/>
+                <rect x="175" y="80" width="15" height="30" fill="white"/>
+
+              </svg>
+            </div>
+
+            <p class="text-sm text-stone-600 leading-relaxed">
+              ご本人の見やすい位置で端末の画面を見せて、カテゴリを提示します。
+            </p>
+
+          </div>
+        </div>
+
+        <!-- STEP 2 -->
+        <div class="relative flex items-start gap-4 z-10">
+
+          <div class="flex items-center justify-center w-10 h-10 rounded-full bg-white border-2 border-amber-600 text-amber-700 font-bold text-lg shadow-sm shrink-0">
+            2
+          </div>
+
+          <div class="flex-1 bg-white p-5 rounded-2xl shadow-sm space-y-4">
+
+            <h4 class="font-bold text-stone-800">項目を指差し、まばたきで確認</h4>
+
+            <div class="aspect-video bg-stone-100 rounded-xl flex items-center justify-center">
+              <svg viewBox="0 0 260 160" class="w-56">
+
+                <!-- スマホ -->
+                <rect x="40" y="40" width="80" height="100" rx="10" fill="#1f2937"/>
+                <rect x="55" y="55" width="50" height="15" fill="#fde68a"/>
+                <rect x="55" y="75" width="50" height="15" fill="#e7e5e4"/>
+
+                <!-- 指差し -->
+                <line x1="150" y1="80" x2="105" y2="65"
+                      stroke="#f59e0b"
+                      stroke-width="4"/>
+
+                <!-- 本人 -->
+                <circle cx="190" cy="70" r="18" fill="#a8a29e"/>
+
+                <!-- まばたき -->
+                <line x1="180" y1="70" x2="200" y2="70"
+                      stroke="#1f2937"
+                      stroke-width="2">
+                  <animate attributeName="opacity"
+                           values="1;0;1"
+                           dur="1.2s"
+                           repeatCount="indefinite"/>
+                </line>
+
+              </svg>
+            </div>
+
+            <p class="text-sm text-stone-600 leading-relaxed space-y-2">
+              <span class="block">
+                画面の項目を指差します。
+              </span>
+
+              <span class="block italic text-amber-700 font-semibold">
+                「〇〇であっていたら、まばたきしてください」
+              </span>
+
+              <span class="block">
+                まばたきしたら、その項目を選択します。
+              </span>
+            </p>
+
+
+          </div>
+        </div>
+
+        <!-- STEP 3 -->
+        <div class="relative flex items-start gap-4 z-10">
+
+          <div class="flex items-center justify-center w-10 h-10 rounded-full bg-white border-2 border-amber-600 text-amber-700 font-bold text-lg shadow-sm shrink-0">
+            3
+          </div>
+
+          <div class="flex-1 bg-white p-5 rounded-2xl shadow-sm space-y-4">
+
+            <h4 class="font-bold text-stone-800">最終確認して決定</h4>
+
+            <div class="aspect-video bg-stone-100 rounded-xl flex items-center justify-center">
+              <svg viewBox="0 0 260 170" class="w-56">
+
+                <!-- 全体カード -->
+                <rect x="30" y="30" width="200" height="110" rx="16"
+                      fill="white" stroke="#e7e5e4"/>
+
+                <!-- 選択カテゴリ -->
+                <text x="130" y="55"
+                      text-anchor="middle"
+                      font-size="11"
+                      fill="#78716c">
+                  飲みもの
+                </text>
+
+                <!-- 矢印 -->
+                <text x="130" y="70"
+                      text-anchor="middle"
+                      font-size="12"
+                      fill="#a8a29e">
+                  ↓
+                </text>
+
+                <!-- 選択項目 -->
+                <text x="130" y="85"
+                      text-anchor="middle"
+                      font-size="14"
+                      fill="#1f2937"
+                      font-weight="bold">
+                  水
+                </text>
+
+                <!-- あっていますか？ -->
+                <text x="130" y="105"
+                      text-anchor="middle"
+                      font-size="12"
+                      fill="#44403c">
+                  あっていますか？
+                </text>
+                <!-- はいボタン（左） -->
+                <rect x="65" y="115" width="60" height="22" rx="10"
+                      fill="#f59e0b"/>
+                <text x="95" y="130"
+                      text-anchor="middle"
+                      font-size="11"
+                      fill="white">
+                  はい
+                </text>
+
+                <!-- いいえボタン（右） -->
+                <rect x="135" y="115" width="60" height="22" rx="10"
+                      fill="#e7e5e4"/>
+                <text x="165" y="130"
+                      text-anchor="middle"
+                      font-size="11"
+                      fill="#44403c">
+                  いいえ
+                </text>
+
+                <!-- タップエフェクト（はい側） -->
+                <circle cx="95" cy="126" r="28"
+                        fill="none"
+                        stroke="#f59e0b"
+                        stroke-width="2"
+                        opacity="0.25">
+                  <animate attributeName="r"
+                          values="28;38;28"
+                          dur="1.2s"
+                          repeatCount="indefinite"/>
+                </circle>
+              </svg>
+            </div>
+            <p class="text-sm text-stone-600 leading-relaxed space-y-2">
+              <span class="block italic text-amber-700 font-semibold">
+                「〇〇であっていたら、まばたきしてください」
+              </span>
+
+              <span class="block">
+                まばたきしたら「はい」を選択します。
+              </span>
+
+              <span class="block text-xs text-stone-500">
+                ※ログインしている場合、履歴に保存されます。
+              </span>
+            </p>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    </section>
+
+<!-- カスタマイズ機能 -->
+<section class="w-full mb-14">
+
+  <div class="flex items-center gap-2 mb-6 px-2">
+    <span class="material-symbols-outlined text-amber-700">tune</span>
+    <h3 class="text-lg font-bold text-stone-800">
+      ご本人に合わせてカスタマイズ
+    </h3>
+  </div>
+
+  <div class="bg-white rounded-2xl p-6 shadow-sm border border-stone-100 space-y-6">
+
+    <!-- ① -->
+    <div class="flex items-start gap-4">
+      <div class="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+        <span class="material-symbols-outlined text-amber-700 text-[18px]">
+          add
+        </span>
+      </div>
+      <div>
+        <p class="font-semibold text-stone-800">
+          カテゴリや項目を追加できます
+        </p>
+        <p class="text-sm text-stone-600 leading-relaxed">
+          ログインすると自由に追加できます。
+        </p>
+        <p class="text-xs text-stone-500 leading-relaxed mt-1">
+          ※今後、編集や削除、並び替え機能を追加予定です。
+        </p>
+      </div>
+    </div>
+
+    <!-- ② -->
+    <div class="flex items-start gap-4">
+      <div class="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+        <span class="material-symbols-outlined text-amber-700 text-[18px]">
+          favorite
+        </span>
+      </div>
+      <div>
+        <p class="font-semibold text-stone-800">
+          よく使う言葉だけを並べられます
+        </p>
+        <p class="text-sm text-stone-600 leading-relaxed">
+          生活や体調に合わせて調整できます。
+        </p>
+      </div>
+    </div>
+
+    <!-- ③ -->
+    <div class="flex items-start gap-4">
+      <div class="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+        <span class="material-symbols-outlined text-amber-700 text-[18px]">
+          auto_awesome
+        </span>
+      </div>
+      <div>
+        <p class="font-semibold text-stone-800">
+          その人だけのコミュニケーション環境に
+        </p>
+        <p class="text-sm text-stone-600 leading-relaxed">
+          使い続けるほど、使いやすく育っていきます。
+        </p>
+      </div>
+    </div>
+
+  </div>
+
+</section>
+
+
+    <!-- 戻る -->
+    <section class="w-full mb-6">
+      <%= link_to "設定に戻る",
+          settings_path,
+          class: "
+            w-full h-14
+            flex items-center justify-center
+            rounded-full
+            bg-amber-600
+            text-white
+            text-lg font-bold
+            shadow
+            hover:bg-amber-700
+            active:scale-[0.98]
+            transition
+          "
+      %>
+    </section>
+
   </div>
 </main>


### PR DESCRIPTION
## 概要
- 使い方ガイドページを作成・整備しました。
- 初見ユーザーがアプリの目的や操作フローを理解できるように、UIに沿った3ステップ構成で図解を実装しました。

## 変更内容
- 設定画面から遷移できる「使い方ガイド」ページを実装
- トップページとUIトーン（stone × amber）を統一
- 以下の3ステップを図解付きで説明
  - カテゴリ提示
  - 指差し＋まばたき確認
  - 最終確認（実際のUI構造を反映）
- 確認画面SVGを実際のUI構造（カテゴリ→項目→あっていますか？→はい／いいえ）に修正
- 「ログインでカスタマイズ可能」であることを明示
- カテゴリ・項目の追加機能を説明
- 今後の編集／削除／並び替え機能予定を補足
- 読みやすさ向上のため文章を分解し、セリフ部分を強調表示

## 今後の改善候補（別Issue）
- SVGデザインのさらなる統一
- ダークモード最適化
- アニメーション調整
- 文言のi18n対応

## 動作確認
- 設定ページから正常に遷移すること
- レイアウト崩れがないこと
- SVGが正しく表示されること
- 戻るボタンが設定ページへ遷移すること