### PR TITLE
体調カテゴリに「かゆい」をsystem FlowItemとして追加（seed更新）

### DIFF
--- a/db/seeds/flow_items_body.rb
+++ b/db/seeds/flow_items_body.rb
@@ -1,4 +1,4 @@
-body = MessageCategory.find_by!(key: "body")
+body = MessageCategory.find_by!(key: "body", user_id: nil)
 
 items = [
   {
@@ -18,12 +18,20 @@ items = [
     position: 2
   },
   {
+      key: "itchy",
+      name: "かゆい",
+      kana: "かゆい",
+      icon: "sentiment_stressed",
+      icon_color: "text-yellow-500",
+      position: 3
+    },
+  {
     key: "hot",
     name: "暑い",
     kana: "あつい",
     icon: "wb_sunny",
     icon_color: "text-orange-500",
-    position: 3
+    position: 4
   },
   {
     key: "cold",
@@ -31,7 +39,7 @@ items = [
     kana: "さむい",
     icon: "ac_unit",
     icon_color: "text-cyan-600",
-    position: 4
+    position: 5
   }
 ]
 

--- a/db/seeds/flow_items_drink.rb
+++ b/db/seeds/flow_items_drink.rb
@@ -1,4 +1,4 @@
-drink = MessageCategory.find_by!(key: "drink")
+drink = MessageCategory.find_by!(key: "drink", user_id: nil)
 
 items = [
   {

--- a/db/seeds/flow_items_feeling.rb
+++ b/db/seeds/flow_items_feeling.rb
@@ -1,4 +1,4 @@
-feeling = MessageCategory.find_by!(key: "feeling")
+feeling = MessageCategory.find_by!(key: "feeling", user_id: nil)
 
 items = [
   {

--- a/db/seeds/flow_items_request.rb
+++ b/db/seeds/flow_items_request.rb
@@ -1,4 +1,4 @@
-request = MessageCategory.find_by!(key: "request")
+request = MessageCategory.find_by!(key: "request", user_id: nil)
 
 items = [
   {


### PR DESCRIPTION
## 概要
- 体調（body）カテゴリに「かゆい」を system FlowItem として追加しました。
- systemデータは「進化するテンプレート」として扱う方針のため、seedを更新し、本番でも rails db:seed により反映可能な構成としています。

## 変更内容
- bodyカテゴリに以下のFlowItemを追加
  - key: itchy
  - name: かゆい
  - position: 3
- 既存項目のpositionを調整
  - 苦しい（1）
  - 痛い（2）
  - かゆい（3）
  - 暑い（4）
  - 寒い（5）
- seed処理は冪等（find_or_initialize_by + assign_attributes）で実装
- systemデータ限定のため user_id: nil を明示

## 動作確認
- ローカルで rails db:seed を2回実行し、冪等性を確認
- positionが期待通りに更新されることを確認
- 既存FlowItemの重複作成が発生しないことを確認