### PR TITLE
refactor: icon定義をlibへ集約し定数管理へ移行

### DIFF
--- a/app/helpers/flow_items_helper.rb
+++ b/app/helpers/flow_items_helper.rb
@@ -1,12 +1,5 @@
 module FlowItemsHelper
   def flow_item_icons
-    %w[
-      water_drop
-      local_bar
-      emoji_food_beverage
-      coffee
-      sports_bar
-      liquor
-    ]
+    IconDefinitions::FLOW_ITEM_ICONS
   end
 end

--- a/app/helpers/message_categories_helper.rb
+++ b/app/helpers/message_categories_helper.rb
@@ -1,19 +1,9 @@
 module MessageCategoriesHelper
   def message_category_icons
-    {
-      "local_cafe" => "飲みもの",
-      "accessibility_new" => "体調",
-      "sentiment_satisfied_alt" => "気持ち",
-      "volunteer_activism" => "お願い"
-    }
+    IconDefinitions::CATEGORY_ICONS.transform_values { |v| v[:label] }
   end
 
   def icon_color(icon)
-    {
-      "local_cafe" => "text-orange-500",
-      "accessibility_new" => "text-sky-500",
-      "sentiment_satisfied_alt" => "text-rose-400",
-      "volunteer_activism" => "text-emerald-500"
-    }[icon] || "text-gray-400"
+    IconDefinitions::CATEGORY_ICONS.dig(icon, :color) || "text-gray-400"
   end
 end

--- a/lib/icon_definitions.rb
+++ b/lib/icon_definitions.rb
@@ -1,0 +1,23 @@
+module IconDefinitions
+  # カテゴリ用アイコン定義
+  # key: Material Symbols の識別名（DBに保存される値）
+  # value: label（表示ラベル）, color（Tailwind カラークラス）
+  # 既存アイコン名を削除すると既存DBデータが孤立するため、削除禁止。
+  CATEGORY_ICONS = {
+    "local_cafe"              => { label: "飲みもの", color: "text-orange-500" },
+    "accessibility_new"       => { label: "体調",     color: "text-sky-500" },
+    "sentiment_satisfied_alt" => { label: "気持ち",   color: "text-rose-400" },
+    "volunteer_activism"      => { label: "お願い",   color: "text-emerald-500" }
+  }.freeze
+
+  # FlowItem用アイコン定義
+  # 既存アイコン名を削除すると既存DBデータが孤立するため、削除禁止。
+  FLOW_ITEM_ICONS = %w[
+    water_drop
+    local_bar
+    emoji_food_beverage
+    coffee
+    sports_bar
+    liquor
+  ].freeze
+end


### PR DESCRIPTION
## 概要
- icon定義をhelperから `lib/icon_definitions.rb` に集約し、定数管理へ移行しました。
- 表示ロジック（Helper）の責務を「変換」に限定し、定義データと分離する構造へ整理しています。

## 背景
- icon定義がHelper内に分散していた
- 今後アイコン選択肢を拡張する予定（#139 PR-2）
- 定義と表示ロジックの責務を分離したい

## 変更内容

### 追加
- `lib/icon_definitions.rb` を新規作成
  - `CATEGORY_ICONS`
  - `FLOW_ITEM_ICONS`
  - `.freeze` により不変化

### 修正
- `message_category_icons`
  - `Hash<String, String>` の戻り値契約を維持
- `flow_item_icons`
  - `Array<String>` の戻り値契約を維持
- `icon_color`
  - `.dig + || "text-gray-400"` により nil安全性を維持

## 影響範囲

- View変更なし
- DB変更なし
- Migrationなし
- 挙動変更なし（リファクタリングのみ）

## 設計意図

- libを「定義層」とし、Helperを「変換層」に分離
- 将来のアイコン拡張（#139 PR-2）を安全に行える基盤を整備
- 外部から見えるAPI（戻り値型・nil安全性）は維持

## 動作確認

- rails runner にて定数読み込み確認済み
- icon_color のデフォルト挙動確認済み
- 既存UIで表示崩れなし
