### PR TITLE
feat: system カテゴリをコピーしてユーザー編集可能にする

### DIFF
--- a/app/controllers/message_categories_controller.rb
+++ b/app/controllers/message_categories_controller.rb
@@ -1,6 +1,6 @@
 class MessageCategoriesController < ApplicationController
   include MessageCategoriesHelper
-  before_action :authenticate_user!, only: %i[new create edit update destroy]
+  before_action :authenticate_user!, only: %i[new create edit update destroy copy]
   before_action :set_message_category, only: %i[edit update destroy]
 
   def index
@@ -12,15 +12,35 @@ class MessageCategoriesController < ApplicationController
     @message_category = MessageCategory.new(icon: default_icon)
   end
 
+  def copy
+    source = MessageCategory.where(user_id: nil).find(params[:id])
+    @message_category = MessageCategory.new(
+      name: source.name,
+      kana: source.kana,
+      icon: source.icon,
+      icon_color: IconDefinitions::ICON_COLORS.key?(source.icon_color) ? source.icon_color : "gray"
+    )
+    @source_category_id = source.id
+    render :new
+  end
+
   def create
     @message_category =
       current_user.message_categories.build(message_category_params)
-
-    if @message_category.save
-      redirect_to message_categories_path
-    else
-      render :new, status: :unprocessable_entity
+    ApplicationRecord.transaction do
+      @message_category.save!
+      copy_flow_items_from(params[:source_category_id]) if params[:source_category_id].present?
     end
+
+    if params[:source_category_id].present?
+      redirect_to message_category_flow_items_path(@message_category),
+                  notice: t("message_categories.copy.success")
+    else
+      redirect_to message_categories_path
+    end
+  rescue ActiveRecord::RecordInvalid
+    @source_category_id = params[:source_category_id]
+    render :new, status: :unprocessable_entity
   end
 
   def edit; end
@@ -49,5 +69,21 @@ class MessageCategoriesController < ApplicationController
   def message_category_params
     params.require(:message_category)
           .permit(:name, :kana, :icon, :icon_color)
+  end
+
+  def copy_flow_items_from(source_id)
+    source = MessageCategory.where(user_id: nil).find_by(id: source_id)
+    return unless source
+
+    source.flow_items.where(user_id: nil).order(:position).each_with_index do |item, idx|
+      @message_category.flow_items.create!(
+        name: item.name,
+        kana: item.kana,
+        icon: item.icon,
+        icon_color: IconDefinitions::ICON_COLORS.key?(item.icon_color) ? item.icon_color : "gray",
+        user: current_user,
+        position: idx + 1
+      )
+    end
   end
 end

--- a/app/views/message_categories/index.html.erb
+++ b/app/views/message_categories/index.html.erb
@@ -34,6 +34,15 @@
               </div>
             </div>
           <% end %>
+          <% if current_user && !message_category.user_id? %>
+            <div data-edit-mode-target="editOnly"
+                 class="hidden absolute top-2 right-2 z-10">
+              <%= link_to copy_message_category_path(message_category),
+                  class: "w-8 h-8 flex items-center justify-center rounded-full bg-green-100 text-green-600 hover:bg-green-200 transition" do %>
+                <span class="material-symbols-outlined text-[18px]!">content_copy</span>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/message_categories/new.html.erb
+++ b/app/views/message_categories/new.html.erb
@@ -2,7 +2,7 @@
   <div class="max-w-md mx-auto">
 
     <%= form_with model: @message_category, local: true, data: { turbo: false } do |f| %>
-
+      <%= hidden_field_tag :source_category_id, @source_category_id if @source_category_id.present? %>
       <% if @message_category.errors.any? %>
         <div class="mb-4 rounded-xl bg-red-50 p-4 text-sm text-red-700">
           <ul class="list-disc pl-5 space-y-1">
@@ -51,6 +51,7 @@
       <!-- 保存ボタン -->
       <div class="mt-2">
         <%= f.submit "保存",
+          data: { disable_with: "保存中..." },
           class: "
             w-full bg-amber-600
             hover:bg-orange-600

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,8 @@ ja:
       confirm: "このカテゴリを削除しますか？"
     update:
       success: "カテゴリを更新しました"
+    copy:
+      success: "カテゴリをコピーしました。フロー項目を編集できます"
   flow_items:
     destroy:
       success: "項目を削除しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   root to: "homes#top"
 
   resources :message_categories, only: %i[index new create edit update destroy] do
+    get :copy, on: :member
     resources :flow_items, only: %i[index new create edit update destroy] do
       get :confirm, on: :member
     end


### PR DESCRIPTION
## 概要
- system 管理の MessageCategory をベースに、ユーザー固有のカテゴリを作成できる「コピーして編集」機能を追加する。

  ## 背景
- デフォルトカテゴリは system 管理のため編集・削除不可だが、文言変更や項目のカスタマイズニーズがある。
- system データの安全性を保ったまま、ユーザーごとのカスタマイズを可能にする。

  ## 実装内容
  - system カテゴリに「コピーして編集」ボタンを追加（編集モード時のみ表示）
  - `copy` アクションで名前・よみ・アイコン・カラーをプリフィルした新規作成画面へ遷移
  - 保存時にトランザクションで MessageCategory と FlowItem を一括複製
  - コピー後は FlowItem 一覧へリダイレクトし、複製された項目を即確認・編集可能

  ## 動作確認
  - [x] system カテゴリは編集・削除できない
  - [x] 編集モードで system カテゴリにコピーボタンが表示される
  - [x] コピー操作で値がプリフィルされた新規作成画面へ遷移する
  - [x] 保存後、ユーザー管理カテゴリとして扱われる
  - [x] FlowItem 一覧に複製された項目が表示される
  - [x] system データ（user_id: nil）が変更されていない
  - [x] bin/rubocop -f github 成功
  - [x] bin/brakeman 成功