### PR TITLE
fix: コピー時に一部アイコンが選択されない問題を修正

### DIFF
--- a/lib/icon_definitions.rb
+++ b/lib/icon_definitions.rb
@@ -5,8 +5,9 @@ module IconDefinitions
   # 既存アイコン名を削除すると既存DBデータが孤立するため、削除禁止。
   CATEGORY_ICONS = {
     "local_cafe"          => { label: "飲みもの" },
+    "local_drink"          => { label: "飲みもの" },
     "accessibility_new"   => { label: "体調" },
-    "sentiment_satisfied" => { label: "気持ち" },
+    "sentiment_satisfied_alt" => { label: "気持ち" },
     "volunteer_activism"  => { label: "お願い" },
     "home"                => { label: "生活・家" },
     "restaurant"          => { label: "食事" },


### PR DESCRIPTION
## 概要
- system カテゴリのコピー時、「飲みもの」「気持ち」のアイコンがicon picker で選択済みにならない問題を修正する。

  ## 原因
 - DB に保存されている icon 値が CATEGORY_ICONS に存在しなかった。

  | カテゴリ | DB の値 | 状況 |
  |----------|---------|------|
  | 飲みもの | `local_drink` | CATEGORY_ICONS になかった |
  | 気持ち | `sentiment_satisfied_alt` | CATEGORY_ICONS になかった |

 - icon picker は CATEGORY_ICONS のキーを元にラジオボタンを生成するため、一致するキーがないと選択済み状態にならない。

  ## 修正内容
  `lib/icon_definitions.rb` の CATEGORY_ICONS に2キーを追加。

  ## 動作確認

  - [x] 飲みもの・気持ちカテゴリのコピー時にアイコンが選択済みで表示される
  - [x] 体調・お願いカテゴリのコピーは引き続き正常動作する