### PR TITLE
fix: ダークモードを無効化する

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,2 +1,4 @@
 @import "tailwindcss";
-@plugin "daisyui";
+@plugin "daisyui" {
+  themes: light --default;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
 
     <!-- Theme Color -->
     <meta name="theme-color" content="#fb8603">
-
+    <meta name="color-scheme" content="light">
     <%= yield :head %>
 
     <% if Rails.env.production? && ENV["GA_MEASUREMENT_ID"].present? %>


### PR DESCRIPTION
## 背景                                                                                                                                                                                                         
- OS のダークモードが有効な環境で、DaisyUI が `prefers-color-scheme: dark` を検知して自動的にダークテーマへ切り替わっていた。
- カスタムトークン（`bg-card-light` 等）が未定義だったため、暗くなった際にカードやテキストが正常に表示されない問題が発生していた。

## 対応内容
- DaisyUI のテーマ設定を `light --default` に変更し、dark テーマの CSS 出力を無効化
- `<meta name="color-scheme" content="light">` を追加（ブラウザ UI への補足）

  ## 変更ファイル
  - `app/assets/stylesheets/application.tailwind.css`
  - `app/views/layouts/application.html.erb`