### PR TITLE
fix: トップページ 基本STEP2のSVGが小画面で見切れる問題を修正

### DIFF
--- a/app/views/shared/_steps.html.erb
+++ b/app/views/shared/_steps.html.erb
@@ -59,8 +59,8 @@
 
             <h4 class="font-bold text-stone-800">項目を指差し、まばたきで確認</h4>
 
-            <div class="aspect-video bg-stone-100 rounded-xl flex items-center justify-center">
-              <svg viewBox="0 0 360 220" class="w-72">
+            <div class="bg-stone-100 rounded-xl flex items-center justify-center">
+              <svg viewBox="0 0 360 220" class="w-full">
 
                 <!-- スマホ -->
                 <rect x="20" y="10" width="190" height="200" rx="20"


### PR DESCRIPTION
## 問題
-  _steps.html.erb の STEP2 イラストが小画面で枠から見切れていた。
## 原因
- SVGに `w-72`（288px固定）を指定していたため、カード幅より大きくなる画面サイズで横にはみ出していた
- コンテナが `aspect-video`（16:9）で、SVGの比率（360:220）と合っていなかったため縦も合わなかった
## 修正
- コンテナ：`aspect-video` を削除し、高さをSVGに合わせて自動調整
- SVG：`w-72` → `w-full` に変更し、カード幅に追従させる