### PR TITLE
fix: rubocopのSpaceInsideArrayLiteralBrackets lintエラーを解消

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,5 +4,5 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false


### PR DESCRIPTION
## 概要
- RuboCopの`Layout/SpaceInsideArrayLiteralBrackets` ルールが有効になっており、CIでlintエラーが発生していたため、明示的に無効化した。

## 背景
- `.rubocop.yml` に `Enabled: false` の設定が記述されていたが、
- コメントアウト状態だったためルールが適用されていなかった。
- コードベースはスペースあり・なしが混在しており、
- 統一コストが高いため今回はルール無効化で対応する。

## 変更内容
  - `.rubocop.yml`: `Layout/SpaceInsideArrayLiteralBrackets` のコメントを外し有効化