### PR TITLE
feat: タブレット向けレスポンシブ対応（視線操作 Phase 1）

### DIFF
--- a/app/views/category_flows/show.html.erb
+++ b/app/views/category_flows/show.html.erb
@@ -3,10 +3,10 @@
 <% end %>
 
 <main class="relative min-h-screen w-full bg-stone-200 overflow-x-hidden pb-24">
-  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md mx-auto">
+  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md md:max-w-4xl mx-auto">
 
     <!-- フロー項目一覧 -->
-    <div class="grid grid-cols-2 gap-4 w-full">
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full">
       <% @items.each do |item| %>
         <%= link_to confirm_flow_item_path(item),
             class: "
@@ -23,7 +23,7 @@
           <!-- アイコン -->
           <span class="
             material-symbols-outlined
-            text-[48px] mb-3
+            text-[48px] md:text-[88px] mb-3
             <%= item[:color] %>
             group-hover:scale-110
             transition-transform

--- a/app/views/detail_flows/show.html.erb
+++ b/app/views/detail_flows/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <main class="flex-grow px-6 pb-24 pt-6 flex flex-col items-center">
-    <div class="w-full max-w-md">
+    <div class="w-full max-w-md md:max-w-xl">
       <p class="text-sm text-text-sub-light dark:text-text-sub-dark mb-4">
         <%= t("detail_flows.step_of", current: @step_index + 1, total: @flow_definition[:steps].length) %>
       </p>

--- a/app/views/flow_items/index.html.erb
+++ b/app/views/flow_items/index.html.erb
@@ -6,10 +6,10 @@
 <% content_for :edit_mode_enabled, true %>
 
 <main class="relative min-h-screen w-full bg-stone-200 overflow-x-hidden pb-24">
-  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md mx-auto">
+  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md md:max-w-4xl mx-auto">
 
     <!-- フロー項目一覧 -->
-    <div class="grid grid-cols-2 gap-4 w-full"
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full"
          data-controller="reorder"
          data-reorder-url-value="<%= reorder_message_category_flow_items_path(@message_category) %>">
       <% @flow_items.each do |item| %>

--- a/app/views/message_categories/index.html.erb
+++ b/app/views/message_categories/index.html.erb
@@ -5,13 +5,13 @@
 <% content_for :edit_mode_enabled, true %>
 
 <main class="relative min-h-screen w-full bg-stone-200 pb-24">
-  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md mx-auto">
+  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md md:max-w-4xl mx-auto">
 
     <!-- カテゴリ一覧 -->
     <%# TODO: 並び替えUIは一時的に非表示。system カテゴリを含む全体並び替えが
         設計できた時点で reorder コントローラーを復活させる。
         バックエンド（reorder アクション・position カラム）は残存。 %>
-    <div class="grid grid-cols-2 gap-4 w-full">
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full">
       <% @message_categories.each do |message_category| %>
         <%# data-reorder-card / data-id は reorder 復活時に再追加する %>
         <div class="relative">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <main class="relative min-h-screen w-full bg-stone-200 overflow-x-hidden pb-24">
-  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md mx-auto space-y-6">
+  <div class="flex flex-col items-center px-4 pt-6 w-full max-w-md md:max-w-xl mx-auto space-y-6">
 
     <%# =========================
         はじめての方へ（安心導線）

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -11,7 +11,7 @@
 <% analytics_active = controller_name == "analytics" %>
 
 <nav class="fixed bottom-0 left-0 w-full bg-white/90 backdrop-blur border-t border-stone-200 pb-safe pt-2 px-6 shadow-[0_-4px_10px_-4px_rgba(0,0,0,0.05)] z-50">
-  <div class="flex justify-around items-end pb-2 max-w-md mx-auto">
+  <div class="flex justify-around items-end pb-2 max-w-md md:max-w-4xl mx-auto">
 
     <!-- メッセージ -->
     <%= link_to message_categories_path,

--- a/app/views/shared/_square_card.html.erb
+++ b/app/views/shared/_square_card.html.erb
@@ -13,7 +13,7 @@
   <!-- アイコン -->
   <span class="
     material-symbols-outlined
-    !text-[52px]
+    !text-[52px] md:!text-[88px]
     <%= icon_color %>
     transition-transform
     group-hover:scale-110
@@ -22,9 +22,9 @@
   </span>
 
   <!-- テキストエリア -->
-  <div class="h-[72px] flex flex-col justify-center">
+  <div class="h-[72px] md:h-[120px] flex flex-col justify-center md:gap-3">
     <span class="
-      text-[22px]
+      text-[22px] md:text-[34px]
       font-bold
       text-stone-900
       leading-tight
@@ -34,7 +34,7 @@
     </span>
 
     <span class="
-      text-[15px]
+      text-[15px] md:text-[22px]
       text-stone-700
       leading-tight
       line-clamp-2


### PR DESCRIPTION
## 概要
- 視線・まばたき操作機能の実装に向けた第1フェーズ。
- タブレット（iPad Pro 1024px）でカードを大きく表示し、視線で選びやすいUIの基盤を作る。

## 変更内容
- カード一覧画面（message_categories・flow_items）をタブレットで `max-w-4xl`・`3列グリッド` に拡張
- `_square_card` のアイコン・文字サイズをタブレットで拡大
- detail_flows・settings・footer の横幅をタブレット向けに調整
- スマホ幅（768px未満）の既存UIは変更なし

## 対応しなかったこと
- カード枚数に応じたグリッド列数の動的切り替えは視線選択MVP完成後に別Issueで対応予定