### PR TITLE
feat: 視線操作向け強調表示CSS基盤を追加（Phase 2）

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,3 +2,26 @@
 @plugin "daisyui" {
   themes: light --default;
 }
+
+@layer utilities {
+  /* 視線が当たっている状態（候補ハイライト） */
+  .gaze-highlight {
+    outline: 3px solid var(--color-amber-500);
+    outline-offset: 2px;
+    background-color: color-mix(in srgb, var(--color-amber-50) 90%, transparent);
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--color-amber-200) 40%, transparent);
+    animation: gaze-pulse 1s ease-in-out infinite;
+  }
+
+  /* dwell安定後の確定待ち状態 */
+  .gaze-confirm {
+    outline: 3px solid var(--color-orange-500);
+    outline-offset: 2px;
+    background-color: color-mix(in srgb, var(--color-orange-50) 90%, transparent);
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-orange-300) 50%, transparent);
+  }
+}
+@keyframes gaze-pulse {
+  0%, 100% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-amber-200) 40%, transparent); }
+  50%       { box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-amber-200) 20%, transparent); }
+}

--- a/app/views/detail_flows/show.html.erb
+++ b/app/views/detail_flows/show.html.erb
@@ -20,7 +20,8 @@
           <% @step[:choices].each do |choice| %>
             <label class="flex items-center gap-4 bg-card-light dark:bg-card-dark
                           rounded-2xl p-5 shadow-sm cursor-pointer
-                          has-[:checked]:border-2 has-[:checked]:border-orange-500">
+                          has-[:checked]:border-2 has-[:checked]:border-orange-500
+                          has-[:checked]:bg-orange-50">
               <%= f.radio_button :answer, choice[:value], class: "hidden" %>
               <span class="text-2xl font-bold"><%= choice[:label] %></span>
             </label>


### PR DESCRIPTION
## 概要
- 視線操作の2段階確認UIに必要なCSSクラスを定義した。
- Phase 3aでJSからクラスを付け外しすることで動作する。

## 変更内容
### app/assets/stylesheets/application.tailwind.css

  `.gaze-highlight`・`.gaze-confirm` を `@layer utilities` に追加。

  | クラス | 用途 | 見た目 |
  |---|---|---|
  | `.gaze-highlight` | 視線が当たっている状態 | 黄色アウトライン・点滅 |
  | `.gaze-confirm` | 長まばたき待ち状態 | オレンジアウトライン・点滅なし |

  アニメーションは `box-shadow` のスプレッド半径を変化させる方式。
  `scale` を使わない理由：カード座標がずれると視線判定に影響するため。

  ### app/views/detail_flows/show.html.erb

  選択済みラジオボタンのラベルに `has-[:checked]:bg-orange-50` を追加。
  「どれが選ばれているか」を視覚的に明確にする。

  ## Phase 対応表

  | Phase | 内容 | 状態 |
  |---|---|---|
  | Phase 1 | タブレット向けレスポンシブ | 完了 |
  | Phase 2 | 強調表示CSS基盤 | 本PR |
  | Phase 3a | FaceMesh + まばたき検出MVP | 未着手 |
  | Phase 3b | 視線方向ゾーン判定 | 未着手 |

  ## 動作確認

  - [ ] `detail_flows` の選択肢をタップすると背景色が変わる
  - [ ] ビルドCSSに `.gaze-highlight`・`.gaze-confirm` が含まれている