### PR TITLE
hotfix: SVG faviconリンクを削除してfaviconが表示されない問題を修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,6 @@
     <link rel="manifest" href="/manifest.json">
 
     <link rel="icon" href="/favicon.ico" sizes="any">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon-192.png">
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
## 概要
`icon.svg` がプレースホルダー（赤い正方形）のままになっており、モダンブラウザが `favicon.ico` より SVG を優先するためfavicon が正常に表示されていなかった。

## 原因
```html
<!-- この行が悪さしていた -->
<link rel="icon" href="/icon.svg" type="image/svg+xml">
```
## 対応
- 上記の <link> タグを1行削除。
- favicon.ico（HTTP 200・正常配信済み）にフォールバックさせる。

## 影響範囲
- アプリの動作：なし
- PWA / manifest.json：なし（icon-192.png / icon-512.png で別管理）
- 変更ファイル：app/views/layouts/application.html.erb のみ