### PR TITLE
test: セキュリティ関連スコープ・バリデーションのRSpecを追加

### DIFF
--- a/spec/factories/flow_items.rb
+++ b/spec/factories/flow_items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :flow_item do
+    name { Faker::Lorem.word }
+    kana { Faker::Lorem.word }
+    icon { IconDefinitions::FLOW_ITEM_ICONS.keys.first }
+    association :message_category
+  end
+end

--- a/spec/models/flow_item_spec.rb
+++ b/spec/models/flow_item_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe FlowItem do
+  describe 'バリデーションチェック' do
+    it "nameがないと保存できない" do
+      flow_item = build(:flow_item, name: nil)
+      expect(flow_item).to be_invalid
+    end
+
+    it "kanaがないと保存できない" do
+      flow_item = build(:flow_item, kana: nil)
+      expect(flow_item).to be_invalid
+    end
+
+    it "iconがないと保存できない" do
+      flow_item = build(:flow_item, icon: nil)
+      expect(flow_item).to be_invalid
+    end
+  end
+
+  describe 'スコープ' do
+    it "for_user(user)はsystem共通とそのユーザーのレコードを返す" do
+      user_a = create(:user)
+      user_b = create(:user)
+      flow_item_a = create(:flow_item, user_id: user_a.id)
+      flow_item_b = create(:flow_item, user_id: user_b.id)
+      system_flow_item = create(:flow_item, user: nil)
+      result = FlowItem.for_user(user_a)
+      expect(result).to include(flow_item_a)
+      expect(result).to include(system_flow_item)
+      expect(result).not_to include(flow_item_b)
+    end
+
+    it "for_user(nil)はsystem共通のみレコードを返す(ゲストユーザーのケース)" do
+      user_flow_item = create(:flow_item, user: create(:user))
+      system_flow_item = create(:flow_item, user: nil)
+      result = FlowItem.for_user(nil)
+      expect(result).to include(system_flow_item)
+      expect(result).not_to include(user_flow_item)
+    end
+  end
+end

--- a/spec/models/message_category_spec.rb
+++ b/spec/models/message_category_spec.rb
@@ -30,5 +30,13 @@ RSpec.describe MessageCategory do
       expect(result).to include(system_category)
       expect(result).not_to include(message_category_b)
     end
+
+    it "for_user(nil)はsystem共通のみレコードを返す(ゲストユーザーのケース)" do
+      user_message_category = create(:message_category, user: create(:user))
+      system_message_category= create(:message_category, user: nil)
+      result = MessageCategory.for_user(nil)
+      expect(result).to include(system_message_category)
+      expect(result).not_to include(user_message_category)
+    end
   end
 end


### PR DESCRIPTION
## 背景
主要モデルのスコープ・バリデーションにテストがなく、セキュリティに直結するfor_userスコープが回帰テストで守られていない状態だった。

## 変更内容
- `spec/factories/flow_items.rb` を新規作成
- `FlowItem` のバリデーションテスト（name / kana / icon）を追加
- `FlowItem` の `for_user` スコープテスト（ユーザーあり・ゲストの両ケース）を追加
- `MessageCategory` の `for_user(nil)` ゲストケースを追加

## テスト
- `bundle exec rspec spec/models/` → 全グリーン

Close #231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト基盤の改善として、フローアイテムとメッセージカテゴリのテストカバレッジを拡充しました。必須項目のバリデーションとユーザースコープの動作検証を追加しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->