### PR TITLE
test: FlowItemsControllerの認可・セキュリティRSpecを追加する

### DIFF
--- a/spec/requests/flow_items_spec.rb
+++ b/spec/requests/flow_items_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "FlowItems", type: :request do
       it "404になる" do
         user = create(:user)
         other_user = create(:user)
-        other_flow_item = create(:flow_item, user: other_user)
+        category = create(:message_category, user: user)
+        other_flow_item = create(:flow_item, message_category: category, user: other_user)
         sign_in user
-        category = other_flow_item.message_category
         get edit_message_category_flow_item_path(category, other_flow_item)
         expect(response).to have_http_status(404)
       end
@@ -20,9 +20,9 @@ RSpec.describe "FlowItems", type: :request do
       it "404になる" do
         user = create(:user)
         other_user = create(:user)
-        other_flow_item = create(:flow_item, user: other_user)
+        category = create(:message_category, user: user)
+        other_flow_item = create(:flow_item, message_category: category, user: other_user)
         sign_in user
-        category = other_flow_item.message_category
         patch message_category_flow_item_path(category, other_flow_item),
               params: { flow_item: { name: "changed" } }
         expect(response).to have_http_status(404)
@@ -35,9 +35,9 @@ RSpec.describe "FlowItems", type: :request do
       it "404になる" do
         user = create(:user)
         other_user = create(:user)
-        other_flow_item = create(:flow_item, user: other_user)
+        category = create(:message_category, user: user)
+        other_flow_item = create(:flow_item, message_category: category, user: other_user)
         sign_in user
-        category = other_flow_item.message_category
         delete message_category_flow_item_path(category, other_flow_item)
         expect(response).to have_http_status(404)
       end
@@ -45,15 +45,16 @@ RSpec.describe "FlowItems", type: :request do
   end
 
   describe "POST /message_categories/:message_category_id/flow_items/reorder" do
-    context "認証済みユーザーが他ユーザーのIDを混ぜた場合" do
+    context "認証済みユーザーが自分のIDと他ユーザーのIDを混ぜた場合" do
       it "403になる" do
         user = create(:user)
         other_user = create(:user)
         category = create(:message_category, user: user)
+        own_flow_item = create(:flow_item, user: user, message_category: category)
         other_flow_item = create(:flow_item, user: other_user)
         sign_in user
         post reorder_message_category_flow_items_path(category),
-              params: { ids: [other_flow_item.id] }
+              params: { ids: [own_flow_item.id, other_flow_item.id] }
         expect(response).to have_http_status(403)
       end
     end


### PR DESCRIPTION
## Summary
- `set_flow_item_for_owner` によるスコープが機能していることをテストで保証
- edit / update / destroy で他ユーザーのflow_itemにアクセスすると404になることを確認
- reorder で他ユーザーのIDを混ぜると403になることを確認

## Test plan
- [x] `bundle exec rspec spec/requests/flow_items_spec.rb` が通ること
- [x] RuboCop・Brakeman が通ること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * フローアイテムのリクエストレベルのテストを追加しました。編集・更新・削除操作で別ユーザーのリソースに対して404を返す挙動、並び替え操作で別ユーザーのIDを含む場合に403を返す挙動を検証するケースを含みます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->