### PR TITLE
test: RSpecカバレッジの追加（MessageLog・AiSummary・DetailFlowCompletionService）

### DIFF
--- a/spec/factories/ai_summaries.rb
+++ b/spec/factories/ai_summaries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ai_summary do
+    association :user
+    content { "テスト用のAI要約テキスト" }
+    generated_at { Time.current }
+  end
+end

--- a/spec/models/ai_summary_spec.rb
+++ b/spec/models/ai_summary_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe AiSummary do
+  describe '#regeneratable?' do
+    context '生成から1日以上経過している場合' do
+      it 'true を返す' do
+        ai_summary = build(:ai_summary, generated_at: 2.days.ago)
+        expect(ai_summary.regeneratable?).to be true
+      end
+    end
+
+    context '生成から1日経過していない場合' do
+      it 'false を返す' do
+        ai_summary = build(:ai_summary, generated_at: 1.hour.ago)
+        expect(ai_summary.regeneratable?).to be false
+      end
+    end
+  end
+
+  describe '#next_regeneratable_at' do
+    it '生成日時の1日後を返す' do
+      generated_at = Time.zone.local(2026, 4, 10, 12, 0, 0)
+      ai_summary = build(:ai_summary, generated_at: generated_at)
+      expect(ai_summary.next_regeneratable_at).to eq(Time.zone.local(2026, 4, 11, 12, 0, 0))
+    end
+  end
+end

--- a/spec/models/message_log_spec.rb
+++ b/spec/models/message_log_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe MessageLog do
+  describe 'スナップショット（capture_snapshot）' do
+    let(:message_category) { create(:message_category, name: "食事", icon_color: "orange") }
+    let(:flow_item) do
+      create(:flow_item,
+             name: "水を飲む",
+             icon: "local_drink",
+             icon_color: "blue",
+             message_category: message_category)
+    end
+    let(:log) { create(:message_log, flow_item: flow_item) }
+
+    it "flow_item_name が保存時の flow_item.name を記録する" do
+      expect(log.flow_item_name).to eq("水を飲む")
+    end
+
+    it "flow_item_icon が保存時の flow_item.icon を記録する" do
+      expect(log.flow_item_icon).to eq("local_drink")
+    end
+
+    it "flow_item_icon_color が保存時の flow_item.icon_color を記録する" do
+      expect(log.flow_item_icon_color).to eq("blue")
+    end
+
+    it "message_category_name が保存時の message_category.name を記録する" do
+      expect(log.message_category_name).to eq("食事")
+    end
+
+    it "message_category_icon_color が保存時の message_category.icon_color を記録する" do
+      expect(log.message_category_icon_color).to eq("orange")
+    end
+
+    context "保存後に flow_item の name が変わっても" do
+      it "log.flow_item_name は変わらない" do
+        expect(log.flow_item_name).to eq("水を飲む")
+        flow_item.update!(name: "ジュースを飲む")
+        expect(log.reload.flow_item_name).to eq("水を飲む")
+      end
+    end
+
+    context "保存後に message_category の name が変わっても" do
+      it "log.message_category_name は変わらない" do
+        expect(log.message_category_name).to eq("食事")
+        message_category.update!(name: "飲み物")
+        expect(log.reload.message_category_name).to eq("食事")
+      end
+    end
+  end
+end

--- a/spec/services/detail_flow_completion_service_spec.rb
+++ b/spec/services/detail_flow_completion_service_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe DetailFlowCompletionService do
+  let(:user) { create(:user) }
+  let(:flow_item) { create(:flow_item) }
+  let(:steps) do
+    [
+      { key: "temperature", label: "体温" },
+      { key: "meal",        label: "食事" }
+    ]
+  end
+  let(:answers) do
+    {
+      "temperature" => { "value" => "normal", "label" => "平熱" },
+      "meal"        => { "value" => "all",    "label" => "完食" }
+    }
+  end
+
+  describe '.call' do
+    context '全stepに回答がある場合' do
+      it 'MessageLog が1件作成される' do
+        expect {
+          DetailFlowCompletionService.call(
+            user: user,
+            flow_item: flow_item,
+            steps: steps,
+            answers: answers
+          )
+        }.to change(MessageLog, :count).by(1)
+      end
+
+      it 'detail_flow_text にステップのラベルと回答が含まれる' do
+        log = DetailFlowCompletionService.call(
+          user: user,
+          flow_item: flow_item,
+          steps: steps,
+          answers: answers
+        )
+        expect(log.detail_flow_text).to eq("体温：平熱、食事：完食")
+      end
+
+      it 'detail_flow_data に answers が保存される' do
+        log = DetailFlowCompletionService.call(
+          user: user,
+          flow_item: flow_item,
+          steps: steps,
+          answers: answers
+        )
+        expect(log.detail_flow_data).to eq(answers)
+      end
+    end
+
+    context 'answers に steps に存在しないキーが含まれる場合' do
+      let(:answers_with_unknown_key) do
+        answers.merge("unknown_key" => { "value" => "xxx", "label" => "不明" })
+      end
+
+      it '不正なキーを除外して MessageLog が作成される' do
+        log = DetailFlowCompletionService.call(
+          user: user,
+          flow_item: flow_item,
+          steps: steps,
+          answers: answers_with_unknown_key
+        )
+        expect(log.detail_flow_data.key?("unknown_key")).to be false
+      end
+
+      it 'detail_flow_text に不正なキーの内容が含まれない' do
+        log = DetailFlowCompletionService.call(
+          user: user,
+          flow_item: flow_item,
+          steps: steps,
+          answers: answers_with_unknown_key
+        )
+        expect(log.detail_flow_text).not_to include("不明")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `MessageLog` のSnapshotパターン全カラムをRSpecで保護する
- `AiSummary` の再生成ロジック（`regeneratable?` / `next_regeneratable_at`）をRSpecで保護する
- `DetailFlowCompletionService` のstepキー絞り込みロジックと正常系をRSpecで保護する

## 追加したファイル

| ファイル | テスト数 |
|---|---|
| `spec/models/message_log_spec.rb` | 7 |
| `spec/models/ai_summary_spec.rb` | 3 |
| `spec/factories/ai_summaries.rb` | - |
| `spec/services/detail_flow_completion_service_spec.rb` | 5 |

合計 **15例、0 failures**（既存テスト含む全40例）

## Test plan

- [x] `bundle exec rspec` が全例パスすること
- [x] RuboCop・Brakeman が通過すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * AI概要機能の再生成可否判定とタイムスタンプ処理に関するテストを追加
  * メッセージログのスナップショット機能のテストを追加
  * 詳細フロー完了サービスの動作検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->