### PR TITLE
chore: simplecovを導入してカバレッジ計測を有効化する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@
 /vendor/bundle
 
 backup.dump
+
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "simplecov", require: false
 end
 
 gem "devise", "~> 4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     drb (2.2.3)
     erb (6.0.1)
     erubi (1.13.1)
@@ -374,6 +375,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -453,6 +460,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
+  simplecov
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'simplecov'
+SimpleCov.start 'rails'
+
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'


### PR DESCRIPTION
## Summary

- `simplecov` gem を導入し、RSpec実行時にカバレッジレポートを自動生成する
- `coverage/` を `.gitignore` に追加して生成ファイルをコミット対象外にする
- 現状のカバレッジ: **27.35%**（40例）

## Test plan

- [x] `bundle exec rspec` が全例パスすること
- [x] RSpec実行後に `coverage/index.html` が生成されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チェア**
  * テスト環境にコードカバレッジ測定機能を追加しました。
  * カバレッジ出力ファイルをバージョン管理から除外する設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->