### PR TITLE
test: AiSummariesControllerの認証・インターバル・正常系・エラーハンドリングをRSpecで保護する

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')

--- a/spec/requests/ai_summaries_spec.rb
+++ b/spec/requests/ai_summaries_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe "AiSummaries", type: :request do
       before { sign_in user }
 
       context "インターバル未経過（生成から1日以内）の場合" do
+        before { create(:message_log, user: user, created_at: 1.day.ago) }
+
         it "analytics_path にリダイレクトされる" do
           create(:ai_summary, user: user, generated_at: 1.hour.ago)
           post ai_summary_path
@@ -31,6 +33,7 @@ RSpec.describe "AiSummaries", type: :request do
       context "インターバルの境界値（ちょうど24時間後）の場合" do
         it "再生成できない" do
           freeze_time do
+            create(:message_log, user: user, created_at: 1.day.ago)
             create(:ai_summary, user: user, generated_at: 24.hours.ago)
             expect(AiSummaryService).not_to receive(:call)
             post ai_summary_path

--- a/spec/requests/ai_summaries_spec.rb
+++ b/spec/requests/ai_summaries_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe "AiSummaries", type: :request do
+  describe "POST /ai_summary" do
+    context "未認証ユーザーの場合" do
+      it "ログインページにリダイレクトされる" do
+        post ai_summary_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      context "インターバル未経過（生成から1日以内）の場合" do
+        it "analytics_path にリダイレクトされる" do
+          create(:ai_summary, user: user, generated_at: 1.hour.ago)
+          post ai_summary_path
+          expect(response).to redirect_to(analytics_path)
+        end
+
+        it "AiSummaryService が呼ばれない" do
+          create(:ai_summary, user: user, generated_at: 1.hour.ago)
+          expect(AiSummaryService).not_to receive(:call)
+          post ai_summary_path
+        end
+      end
+
+      context "インターバルの境界値（ちょうど24時間後）の場合" do
+        it "再生成できない" do
+          freeze_time do
+            create(:ai_summary, user: user, generated_at: 24.hours.ago)
+            expect(AiSummaryService).not_to receive(:call)
+            post ai_summary_path
+          end
+        end
+      end
+
+      context "ログが0件の場合" do
+        it "analytics_path にリダイレクトされる" do
+          post ai_summary_path
+          expect(response).to redirect_to(analytics_path)
+        end
+
+        it "AiSummary が作成されない" do
+          expect { post ai_summary_path }.not_to change(AiSummary, :count)
+        end
+
+        it "AiSummaryService が呼ばれない" do
+          expect(AiSummaryService).not_to receive(:call)
+          post ai_summary_path
+        end
+      end
+
+      context "正常系（ログあり・インターバル経過済み）の場合" do
+        before do
+          create(:message_log, user: user, created_at: 1.day.ago)
+          allow(AiSummaryService).to receive(:call).and_return("テスト用の要約テキスト")
+        end
+
+        it "analytics_path にリダイレクトされる" do
+          post ai_summary_path
+          expect(response).to redirect_to(analytics_path)
+        end
+
+        it "AiSummary が新規作成される" do
+          expect { post ai_summary_path }.to change(AiSummary, :count).by(1)
+        end
+
+        it "content にサービスの戻り値が保存される" do
+          post ai_summary_path
+          expect(user.reload.ai_summary.content).to eq("テスト用の要約テキスト")
+        end
+
+        it "generated_at が更新される" do
+          freeze_time do
+            post ai_summary_path
+            expect(user.reload.ai_summary.generated_at).to be_within(1.second).of(Time.current)
+          end
+        end
+      end
+
+      context "既存の AiSummary を再生成する場合" do
+        before do
+          create(:ai_summary, user: user, generated_at: 2.days.ago, content: "古い要約")
+          create(:message_log, user: user, created_at: 1.day.ago)
+          allow(AiSummaryService).to receive(:call).and_return("新しい要約テキスト")
+        end
+
+        it "AiSummary が新規作成されず更新される" do
+          expect { post ai_summary_path }.not_to change(AiSummary, :count)
+        end
+
+        it "content が新しい内容に更新される" do
+          post ai_summary_path
+          expect(user.reload.ai_summary.content).to eq("新しい要約テキスト")
+        end
+      end
+
+      context "APIタイムアウトが発生した場合" do
+        before do
+          create(:message_log, user: user, created_at: 1.day.ago)
+          allow(AiSummaryService).to receive(:call).and_raise(Anthropic::Errors::APITimeoutError)
+        end
+
+        it "analytics_path にリダイレクトされる" do
+          post ai_summary_path
+          expect(response).to redirect_to(analytics_path)
+        end
+
+        it "AiSummary が作成されない" do
+          expect { post ai_summary_path }.not_to change(AiSummary, :count)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- 未認証・インターバル未経過・ログなし・正常系・タイムアウトの5ケースをカバー
- 外部API呼び出しをモックで差し替え（Anthropic APIを実際に呼ばない）
- 失敗系で `not_to receive(:call)` による副作用の検証を追加
- `freeze_time` で境界値（ちょうど24時間後）のテストを追加
- 既存 AiSummary の再生成（update）ケースを追加
- `ActiveSupport::Testing::TimeHelpers` を `rails_helper.rb` に追加

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `spec/requests/ai_summaries_spec.rb` | 新規作成（15例） |
| `spec/rails_helper.rb` | TimeHelpers を追加 |

## Test plan

- [x] `bundle exec rspec` が全例パスすること（55例）
- [x] RuboCop・Brakeman が通過すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

このプルリクエストは主に内部改善と品質保証に関する変更です：

* **テスト**
  * AI概要（サマリー）生成フローに関する包括的なリクエストテストを追加。認証・再生成間隔・ログ有無・タイムアウト時の挙動をカバー。

* **保守**
  * テスト環境に時間操作用のヘルパーを導入し、時刻に依存する検証の精度と安定性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->