### PR TITLE
test: AnalyticsControllerの認証・正常系・parse_month分岐をRSpecで保護する

### DIFF
--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -22,23 +22,32 @@ RSpec.describe "Analytics", type: :request do
       end
 
       context "params[:month] に正しい値を渡した場合" do
-        it "200 OK を返す" do
+        it "指定月で集計される" do
+          allow(LogStatsService).to receive(:call).and_return({ chart_data: [], detail_data: {} })
           get analytics_path, params: { month: "2026-03" }
           expect(response).to have_http_status(:ok)
+          expect(LogStatsService).to have_received(:call)
+            .with(hash_including(user: user, month: Date.new(2026, 3, 1)))
         end
       end
 
       context "params[:month] が空の場合" do
-        it "当月で 200 OK を返す" do
+        it "当月にフォールバックする" do
+          allow(LogStatsService).to receive(:call).and_return({ chart_data: [], detail_data: {} })
           get analytics_path, params: { month: "" }
           expect(response).to have_http_status(:ok)
+          expect(LogStatsService).to have_received(:call)
+            .with(hash_including(month: Date.current.beginning_of_month))
         end
       end
 
       context "params[:month] が不正な値の場合" do
-        it "当月にフォールバックして 200 OK を返す" do
+        it "不正値でも当月にフォールバックする" do
+          allow(LogStatsService).to receive(:call).and_return({ chart_data: [], detail_data: {} })
           get analytics_path, params: { month: "invalid" }
           expect(response).to have_http_status(:ok)
+          expect(LogStatsService).to have_received(:call)
+            .with(hash_including(month: Date.current.beginning_of_month))
         end
       end
     end

--- a/spec/requests/analytics_spec.rb
+++ b/spec/requests/analytics_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe "Analytics", type: :request do
+  describe "GET /analytics" do
+    context "未認証ユーザーの場合" do
+      it "ログインページにリダイレクトされる" do
+        get analytics_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "認証済みユーザーの場合" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      context "正常系の場合" do
+        it "200 OK を返す" do
+          get analytics_path
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "params[:month] に正しい値を渡した場合" do
+        it "200 OK を返す" do
+          get analytics_path, params: { month: "2026-03" }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "params[:month] が空の場合" do
+        it "当月で 200 OK を返す" do
+          get analytics_path, params: { month: "" }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "params[:month] が不正な値の場合" do
+        it "当月にフォールバックして 200 OK を返す" do
+          get analytics_path, params: { month: "invalid" }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- 未認証・正常系・valid month・空文字・不正値の5ケースをカバー
- `parse_month` の全分岐（正常・空・不正値フォールバック）をテストで保護

## 変更ファイル

| ファイル | テスト数 |
|---|---|
| `spec/requests/analytics_spec.rb` | 5例（新規作成） |

## Test plan

- [ ] `bundle exec rspec` が全例パスすること
- [ ] RuboCop・Brakeman が通過すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * アナリティクス表示のリクエスト仕様テストを追加しました。未認証ユーザーのアクセスがログインページへリダイレクトされること、認証ユーザーが各種月パラメータ（有効・空・無効）でアクセスした際に正常に結果が返ることを検証します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->