### PR TITLE
test: AiSummaryServiceの正常系・ログなし・APIタイムアウトをRSpecで保護する

### DIFF
--- a/spec/services/ai_summary_service_spec.rb
+++ b/spec/services/ai_summary_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AiSummaryService do
       before do
         category = create(:message_category, user: nil, name: "飲み物")
         flow_item = create(:flow_item, message_category: category, user: nil, name: "お茶")
-        3.times { create(:message_log, user: user, message_category_name: "飲み物", flow_item_name: "お茶") }
+        3.times { create(:message_log, user: user, flow_item: flow_item) }
       end
 
       it "要約テキストを返す" do

--- a/spec/services/ai_summary_service_spec.rb
+++ b/spec/services/ai_summary_service_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe AiSummaryService do
+  let(:user) { create(:user) }
+
+  def stub_anthropic(text: "テスト要約")
+    allow_any_instance_of(Anthropic::Client).to receive_message_chain(:messages, :create)
+      .and_return(double(content: [double(text: text)]))
+  end
+
+  describe ".call" do
+    context "ログが1件もない場合" do
+      it "空の集計でも正常終了して要約テキストを返す" do
+        stub_anthropic(text: "ログがありません")
+        result = AiSummaryService.call(user: user)
+        expect(result).to eq("ログがありません")
+      end
+    end
+
+    context "ログがある場合" do
+      before do
+        category = create(:message_category, user: nil, name: "飲み物")
+        flow_item = create(:flow_item, message_category: category, user: nil, name: "お茶")
+        3.times { create(:message_log, user: user, message_category_name: "飲み物", flow_item_name: "お茶") }
+      end
+
+      it "要約テキストを返す" do
+        stub_anthropic(text: "お茶をよく選んでいます")
+        result = AiSummaryService.call(user: user)
+        expect(result).to eq("お茶をよく選んでいます")
+      end
+
+      it "Anthropic::Client に正しいモデルでリクエストを送る" do
+        client_double = instance_double(Anthropic::Client)
+        messages_double = double("messages")
+        allow(Anthropic::Client).to receive(:new).and_return(client_double)
+        allow(client_double).to receive(:messages).and_return(messages_double)
+        allow(messages_double).to receive(:create)
+          .and_return(double(content: [double(text: "要約")]))
+
+        AiSummaryService.call(user: user)
+
+        expect(messages_double).to have_received(:create).with(
+          hash_including(model: AiSummaryService::MODEL)
+        )
+      end
+    end
+
+    context "API タイムアウトが発生した場合" do
+      it "Anthropic::Errors::APITimeoutError が伝播する" do
+        allow_any_instance_of(Anthropic::Client).to receive_message_chain(:messages, :create)
+          .and_raise(Anthropic::Errors::APITimeoutError.new(url: "https://api.anthropic.com"))
+        expect {
+          AiSummaryService.call(user: user)
+        }.to raise_error(Anthropic::Errors::APITimeoutError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- ログなし → 空集計でも正常終了して要約テキストを返す
- ログあり → 正しい要約テキストを返す・正しいモデルで API リクエストを送る
- API タイムアウト → `Anthropic::Errors::APITimeoutError` が伝播する

`generate_summary` は外部 API のため `allow_any_instance_of(Anthropic::Client)` でモック。  
`APITimeoutError` は `:url` キーワード引数が必須のため `new(url: ...)` で raise。

## Test plan

- [x] `bundle exec rspec spec/services/ai_summary_service_spec.rb` 全4件パス
- [x] RuboCop 警告なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * AI要約サービスのテストカバレッジを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->