### PR TITLE
test: AiSummariesController・MessageLogsController・Userモデルの未テスト分岐をRSpecで保護する

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  describe ".from_omniauth" do
+    let(:auth) do
+      OmniAuth::AuthHash.new(
+        provider: "google_oauth2",
+        uid: "123456",
+        info: {
+          name: "テストユーザー",
+          email: "test@example.com"
+        }
+      )
+    end
+
+    context "該当ユーザーが存在しない場合" do
+      it "新規ユーザーを作成する" do
+        expect { User.from_omniauth(auth) }.to change(User, :count).by(1)
+      end
+
+      it "auth の情報でユーザーが作成される" do
+        user = User.from_omniauth(auth)
+        expect(user.name).to eq("テストユーザー")
+        expect(user.email).to eq("test@example.com")
+        expect(user.provider).to eq("google_oauth2")
+        expect(user.uid).to eq("123456")
+      end
+    end
+
+    context "該当ユーザーがすでに存在する場合" do
+      before { create(:user, provider: "google_oauth2", uid: "123456", email: "test@example.com") }
+
+      it "既存ユーザーを返す" do
+        expect { User.from_omniauth(auth) }.not_to change(User, :count)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,10 +28,12 @@ RSpec.describe User do
     end
 
     context "該当ユーザーがすでに存在する場合" do
-      before { create(:user, provider: "google_oauth2", uid: "123456", email: "test@example.com") }
+      let!(:existing_user) { create(:user, provider: "google_oauth2", uid: "123456", email: "test@example.com") }
 
       it "既存ユーザーを返す" do
-        expect { User.from_omniauth(auth) }.not_to change(User, :count)
+        returned_user = nil
+        expect { returned_user = User.from_omniauth(auth) }.not_to change(User, :count)
+        expect(returned_user).to eq(existing_user)
       end
     end
   end

--- a/spec/requests/ai_summaries_spec.rb
+++ b/spec/requests/ai_summaries_spec.rb
@@ -117,6 +117,31 @@ RSpec.describe "AiSummaries", type: :request do
           expect { post ai_summary_path }.not_to change(AiSummary, :count)
         end
       end
+
+      context "Anthropic::Errors::APIError が発生した場合" do
+        before do
+          create(:message_log, user: user, created_at: 1.day.ago)
+          allow(AiSummaryService).to receive(:call)
+            .and_raise(Anthropic::Errors::APIError.new(url: "https://api.anthropic.com", status: 500))
+        end
+
+        it "analytics_path にリダイレクトされる" do
+          post ai_summary_path
+          expect(response).to redirect_to(analytics_path)
+        end
+      end
+
+      context "StandardError が発生した場合" do
+        before do
+          create(:message_log, user: user, created_at: 1.day.ago)
+          allow(AiSummaryService).to receive(:call).and_raise(StandardError)
+        end
+
+        it "analytics_path にリダイレクトされる" do
+          post ai_summary_path
+          expect(response).to redirect_to(analytics_path)
+        end
+      end
     end
   end
 end

--- a/spec/requests/message_logs_spec.rb
+++ b/spec/requests/message_logs_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe "MessageLogs", type: :request do
           params: { flow_item_key: flow_item.key }
         }.to change(MessageLog, :count)
       end
+
+      it "message_completion_path にリダイレクトされる" do
+        user = create(:user)
+        sign_in user
+        flow_item = create(:flow_item)
+        post message_logs_path, params: { flow_item_key: flow_item.key }
+        expect(response).to redirect_to(message_completion_path)
+      end
+    end
+
+    context "未認証ユーザーの場合" do
+      it "session[:last_flow_item_key] に flow_item のキーが保存される" do
+        flow_item = create(:flow_item)
+        post message_logs_path, params: { flow_item_key: flow_item.key }
+        expect(session[:last_flow_item_key]).to eq(flow_item.key)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

**AiSummariesController**
- `Anthropic::Errors::APIError` 発生時 → analytics_path にリダイレクト
- `StandardError` 発生時 → analytics_path にリダイレクト

**MessageLogsController**
- 認証済み create → message_completion_path にリダイレクト確認
- 未認証 create → `session[:last_flow_item_key]` に保存確認

**User モデル**
- `from_omniauth` 新規ユーザー作成
- `from_omniauth` 既存ユーザー取得

## Test plan

- [x] 全27件パス
- [x] RuboCop 警告なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * ユーザー認証フローのテストカバレッジを強化しました
  * APIエラーハンドリングのシナリオテストを追加しました
  * メッセージログの動作検証テストを充実させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->