### PR TITLE
test: MessageCompletionsControllerの4分岐をRSpecで保護する

### DIFF
--- a/spec/requests/message_completions_spec.rb
+++ b/spec/requests/message_completions_spec.rb
@@ -5,12 +5,16 @@ RSpec.describe "MessageCompletions", type: :request do
     context "認証済みユーザー・ログありの場合" do
       it "200 OK を返し、最終ログの flow_item_name が表示される" do
         user = create(:user)
-        flow_item = create(:flow_item)
-        create(:message_log, user: user, flow_item: flow_item)
+        old_item = create(:flow_item, name: "old-name")
+        latest_item = create(:flow_item, name: "latest-snapshot-name")
+        create(:message_log, user: user, flow_item: old_item, created_at: 2.days.ago)
+        create(:message_log, user: user, flow_item: latest_item, created_at: 1.day.ago)
+        latest_item.update!(name: "latest-current-name")
         sign_in user
         get message_completion_path
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include(flow_item.name)
+        expect(response.body).to include("latest-snapshot-name")
+        expect(response.body).not_to include("latest-current-name")
       end
     end
 

--- a/spec/requests/message_completions_spec.rb
+++ b/spec/requests/message_completions_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe "MessageCompletions", type: :request do
+  describe "GET /message_completion" do
+    context "認証済みユーザー・ログありの場合" do
+      it "200 OK を返し、最終ログの flow_item_name が表示される" do
+        user = create(:user)
+        flow_item = create(:flow_item)
+        create(:message_log, user: user, flow_item: flow_item)
+        sign_in user
+        get message_completion_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(flow_item.name)
+      end
+    end
+
+    context "認証済みユーザー・ログなしの場合" do
+      it "200 OK を返す" do
+        user = create(:user)
+        sign_in user
+        get message_completion_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "未認証ユーザー・session に flow_item_key ありの場合" do
+      it "200 OK を返し、flow_item の名前が表示される" do
+        flow_item = create(:flow_item)
+        # 事前POSTでセッションに flow_item_key を積む
+        post message_logs_path, params: { flow_item_key: flow_item.key }
+        get message_completion_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(flow_item.name)
+      end
+    end
+
+    context "未認証ユーザー・session なしの場合" do
+      it "200 OK を返す" do
+        get message_completion_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- 認証済み・ログあり → 200 OK・最終ログの flow_item_name が表示される
- 認証済み・ログなし → 200 OK
- 未認証・session に flow_item_key あり → 事前 POST でセッションを積んで 200 OK・flow_item の名前が表示される
- 未認証・session なし → 200 OK

セッション経由のケースは DetailFlows と同じ手法（事前 POST でセッションに積む）で再現。

## Test plan

- [x] `bundle exec rspec spec/requests/message_completions_spec.rb` 全4件パス
- [x] RuboCop 警告なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * メッセージ完了エンドポイント用の新しいリクエスト仕様テストスイートを追加しました。認証状態、セッション管理、レスポンス検証を含む複数のテストシナリオをカバーしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->