### PR TITLE
fix: migrationでNeonDBのdirect URLを使う

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,6 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate
+
+# migration 時のみ Direct URL を使う（NeonDB PgBouncer 回避）
+DATABASE_URL="$DATABASE_URL_DIRECT" bundle exec rails db:migrate


### PR DESCRIPTION
## Summary

NeonDB の Pooled connection（PgBouncer）が Rails migration の transaction を破壊することが判明したため、migration 実行時のみ Direct URL を使うように修正。

## 背景

ご意見箱機能（PR #285）のデプロイ時に migration が失敗。
\`PG::InFailedSqlTransaction: ERROR: current transaction is aborted\` で死亡。

## 調査の経緯

1. ローカル: migration 成功
2. NeonDB Console で手動 SQL: 成功
3. 本番デプロイ: 失敗
4. 検証: NeonDB Direct URL なら成功、Pooled URL なら失敗 → **PgBouncer が真因確定**

NeonDB 公式も「pooled では advisory lock など session-scoped 機能が動かない」と明記。
Rails migration は advisory lock を使うため衝突していた。

## 変更

- \`bin/render-build.sh\` で migration 時のみ \`DATABASE_URL_DIRECT\` を使う
- Render の Environment Variables に \`DATABASE_URL_DIRECT\` を追加（手動設定済み）

## Test plan

- [x] Render デプロイが成功する
- [x] migration が完走する（key カラム追加 + UUID backfill + NOT NULL + unique index）
- [x] アプリが正常動作する（トップ表示・ログイン・ご意見投稿）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベースマイグレーション処理の最適化を実施しました。これにより、ビルドプロセスの効率性が向上します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/naganobol6212/Mabatalk/pull/286)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->