### PR TITLE
chore: AI設計レビュー基盤（design-review/review-loop/codex-discussion）を追加する

### DIFF
--- a/.claude/skills/codex-discussion/SKILL.md
+++ b/.claude/skills/codex-discussion/SKILL.md
@@ -9,17 +9,19 @@ Claude（Anthropic）の成果物・設計判断を、別ベンダーのモデ�
 
 ## この環境で確認済みの実行方法（2026-07-04 確認・codex-cli 0.132.0）
 
-- 認証: ChatGPT アカウント（`~/.codex/auth.json`）。API キー不要
-- 既定モデル: `gpt-5.5` / reasoning effort `medium`（`~/.codex/config.toml`）
+- 認証: ChatGPT アカウントで認証済み。API キー不要
+- 既定モデル: `gpt-5.5` / reasoning effort `medium`（Codex CLI のユーザー設定による）
 - 非対話実行は `codex exec`（承認プロンプトなしで走る。安全性はサンドボックスフラグで担保する）
 
 ### 基本形
+
+`<リポジトリルートの絶対パス>` は実行時に `git rev-parse --show-toplevel` で解決する（個人環境のパスを直書きしない）。
 
 ```bash
 codex exec \
   --sandbox read-only \
   --ephemeral \
-  -C /Users/naganoma/Projects/Mabatalk \
+  -C <リポジトリルートの絶対パス> \
   -o <出力ファイルの絶対パス> \
   "<依頼文>"
 ```
@@ -32,7 +34,7 @@ codex exec \
 codex exec \
   --sandbox read-only \
   --ephemeral \
-  -C /Users/naganoma/Projects/Mabatalk \
+  -C <リポジトリルートの絶対パス> \
   --output-schema <スキーマファイルの絶対パス> \
   -o <出力ファイルの絶対パス> \
   "<依頼文>"
@@ -51,7 +53,7 @@ codex exec \
 
 ## 依頼文の型（レビュー依頼）
 
-```
+```text
 あなたは独立した設計レビュアーです。以下を読んでレビューしてください。
 
 対象: <ファイルパス（例: /path/to/context.md）> を読むこと
@@ -69,7 +71,7 @@ codex exec \
 
 既出の指摘・主張を疑わせる（反証専用）ときは、依頼文を次の形にする:
 
-```
+```text
 あなたは懐疑的な検証者です。以下の指摘を「反証」することだけを目的に検討してください。
 
 対象コンテキスト: <ファイルパス> を読むこと

--- a/.claude/skills/codex-discussion/SKILL.md
+++ b/.claude/skills/codex-discussion/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: codex-discussion
+description: Claude Code で進める設計・実装・不具合調査について、Codex CLI に第三者レビューまたは往復議論を依頼する skill。依頼文作成・実行・結果回収・報告まで一貫して行う。「Codexにレビューさせて」「セカンドオピニオン」「別の視点」「クロスレビュー」と言われたら使う。本番影響のある変更・設計判断に迷いがある場合は明示がなくても使用を提案する。
+---
+
+# codex-discussion — Codex CLI への第三者レビュー依頼
+
+Claude（Anthropic）の成果物・設計判断を、別ベンダーのモデル（OpenAI Codex）に独立レビューさせて自己バイアスを打ち消すための skill。
+
+## この環境で確認済みの実行方法（2026-07-04 確認・codex-cli 0.132.0）
+
+- 認証: ChatGPT アカウント（`~/.codex/auth.json`）。API キー不要
+- 既定モデル: `gpt-5.5` / reasoning effort `medium`（`~/.codex/config.toml`）
+- 非対話実行は `codex exec`（承認プロンプトなしで走る。安全性はサンドボックスフラグで担保する）
+
+### 基本形
+
+```bash
+codex exec \
+  --sandbox read-only \
+  --ephemeral \
+  -C /Users/naganoma/Projects/Mabatalk \
+  -o <出力ファイルの絶対パス> \
+  "<依頼文>"
+```
+
+### 構造化出力が欲しい場合（推奨・正規化コストが下がる）
+
+最終応答を JSON Schema に強制できる。スキーマをファイルに書いてから:
+
+```bash
+codex exec \
+  --sandbox read-only \
+  --ephemeral \
+  -C /Users/naganoma/Projects/Mabatalk \
+  --output-schema <スキーマファイルの絶対パス> \
+  -o <出力ファイルの絶対パス> \
+  "<依頼文>"
+```
+
+### 運用ルール
+
+- **必ず `--sandbox read-only` を付ける**。Codex に本体を変更させない（`workspace-write` / `--dangerously-bypass-approvals-and-sandbox` は使用禁止）
+- `--ephemeral` でセッションファイルを残さない
+- `-C` でリポジトリを作業ルートにすると、Codex が対象ファイル（contextPath 等）を自分で読める。依頼文には全文を貼らず**ファイルパスを指示して読ませる**（トークン節約）
+- 結果は `-o <FILE>` で回収する（stdout のイベントログはパースしない）。実行後にそのファイルを Read する
+- 長い依頼文は引数でなく stdin で渡せる: `codex exec ... - < prompt.txt`（PROMPT に `-` を指定）
+- モデルを変えたいときのみ `-m <MODEL>` を付ける（通常は config 既定の gpt-5.5 でよい）
+- 実行は数分かかることがある。Bash ツールの timeout は 600000（10 分）に設定する
+- **失敗時のフォールバック禁止**: exit code が非 0、または出力ファイルが空/存在しない場合は「Codex 実行失敗」として理由ごと報告する。**自分（Claude）が代わりにレビューして埋めてはならない**（第三者レビューの意味がなくなる）
+
+## 依頼文の型（レビュー依頼）
+
+```
+あなたは独立した設計レビュアーです。以下を読んでレビューしてください。
+
+対象: <ファイルパス（例: /path/to/context.md）> を読むこと
+観点: <レンズ/観点の指示>
+
+出力形式:
+- 指摘ごとに severity（critical / major / minor / info）を付ける
+  - critical = このままだと動かない/壊れる、major = 高確率で問題化、minor = 改善余地、info = 補足
+- 各指摘に: 一行要約（title）/ 何がどう問題か・具体的な失敗シナリオ（detail）/ 根拠となる一次情報 URL かファイルパス（evidence）/ 推奨する対処（recommendation）
+- 問題なしと確認できた設計判断も「okPoints」として列挙する
+- 日本語で書く
+```
+
+## strict に反証させたい場合の型
+
+既出の指摘・主張を疑わせる（反証専用）ときは、依頼文を次の形にする:
+
+```
+あなたは懐疑的な検証者です。以下の指摘を「反証」することだけを目的に検討してください。
+
+対象コンテキスト: <ファイルパス> を読むこと
+検証する指摘: <指摘の title / detail / evidence>
+
+ルール:
+- 指摘を支持する材料ではなく、指摘が誤り・誇張である可能性を積極的に探すこと
+- 事実確認はリポジトリの実ファイルや一次情報に基づくこと。推測で判定しない
+- 結論は isReal: true / false で明示し、false の場合は correction に正しい事実を書く
+- 判断できない場合は isReal: true（安全側）とする
+```
+
+## 出力の扱い（呼び出し側の責務）
+
+この skill の出力（`-o` のファイル内容）は自然言語または `--output-schema` 準拠の JSON。**呼び出し側が構造化データ（design-review.js の FINDINGS スキーマ: findings[{title, severity, detail, recommendation, evidence}] + okPoints[]）に正規化する前提**である。正規化時に情報を追加・創作しない — Codex が言っていない指摘を足さず、severity の付け直しもしない（欠損フィールドの補完のみ可）。

--- a/.claude/workflows/design-review.js
+++ b/.claude/workflows/design-review.js
@@ -126,7 +126,7 @@ const codexReviewPrompt = (d) =>
     'あなたは Codex CLI の実行係です。設計レビューの中身はあなた自身では行わず、必ず Codex（別ベンダーの独立レビュアー）に実行させ、その結果を回収・正規化してください。',
     '',
     '## 手順',
-    '1. まず /Users/naganoma/Projects/Mabatalk/.claude/skills/codex-discussion/SKILL.md を Read し、そこに書かれた実行コマンド形・運用ルール（--sandbox read-only 必須、-o で結果回収、Bash timeout 600000 など）に厳密に従う',
+    '1. まずリポジトリルート直下の .claude/skills/codex-discussion/SKILL.md を Read し（ルートは `git rev-parse --show-toplevel` で解決する。個人環境の絶対パスを仮定しない）、そこに書かれた実行コマンド形・運用ルール（--sandbox read-only 必須、-o で結果回収、Bash timeout 600000 など）に厳密に従う',
     '2. 下記レンズの観点でのレビュー依頼文を SKILL.md の「依頼文の型」に沿って組み立て、codex exec を実行する',
     '3. 回収した出力を FINDINGS スキーマ（findings + okPoints）に正規化して返す。Codex が言っていない指摘を足さない・severity を付け直さない（欠損フィールドの補完のみ可）',
     '',

--- a/.claude/workflows/design-review.js
+++ b/.claude/workflows/design-review.js
@@ -1,0 +1,246 @@
+// 設計レビュー汎用ハーネス v2 — トークン効率版
+//
+// v1 からの変更（328k トークン枯渇の反省）:
+//   1. モデルルーティング: レビュー/検証は Sonnet 既定（Coordinator=メインループのみ上位モデル）
+//   2. verify を「指摘1件=1エージェント」から「レンズ1つ=1バッチ検証」に集約
+//   3. budget ガード: 残量が閾値未満なら verify をスキップして未検証フラグ付きで返す
+//   4. コンテキストはファイル参照（contextPath）推奨 — プロンプトへの全文再埋め込みを避ける
+//
+// 再開: 失敗時は Workflow({scriptPath, resumeFromRunId, args}) で完了済みエージェントは
+// キャッシュ再生される。ただし model/effort を変えると (prompt, opts) が変わりキャッシュミスに
+// なるため、routing は最初から決めてから回すこと。
+//
+// args:
+//   context      : 設計コンテキスト全文（contextPath とどちらか必須）
+//   contextPath  : コンテキストを書いたファイルの絶対パス（推奨・トークン節約）
+//   dimensions   : [{key, prompt, engine?}] レビューレンズ。engine: 'codex' を指定すると
+//                  そのレンズは Codex CLI による別ベンダー独立レビューになる
+//                  （実行方法は .claude/skills/codex-discussion/SKILL.md に従う）
+//   routing      : 省略可 { reviewModel, verifyModel, reviewEffort, verifyEffort, verifyMinBudget,
+//                  verifyCodexFindings }
+//                  verifyCodexFindings（既定 false）: true のとき Codex 由来の critical/major も
+//                  Claude verify で二重検証する。false なら codex-native として検証を省略
+
+export const meta = {
+  name: 'design-review',
+  description: '設計を複数レンズで並列レビューし、重要指摘をレンズ単位でバッチ反証検証する（Sonnet 既定のトークン効率版）',
+  whenToUse: '実装前の設計・計画レビュー。args に { contextPath | context, dimensions: [{key, prompt}], routing? } を渡す',
+  phases: [
+    { title: 'Review', detail: 'レンズごとに並列レビュー（既定 Sonnet）', model: 'sonnet' },
+    { title: 'Verify', detail: 'レンズ単位で critical/major をバッチ反証検証（既定 Sonnet）', model: 'sonnet' },
+  ],
+}
+
+const FINDINGS = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'severity', 'detail', 'recommendation'],
+        properties: {
+          title: { type: 'string', description: '指摘の一行要約' },
+          severity: { type: 'string', enum: ['critical', 'major', 'minor', 'info'] },
+          detail: { type: 'string', description: '何がどう問題か。具体的な失敗シナリオ' },
+          recommendation: { type: 'string', description: '推奨する対処' },
+          evidence: { type: 'string', description: '根拠（一次情報 URL、ファイルパスなど）' },
+        },
+      },
+    },
+    okPoints: {
+      type: 'array',
+      items: { type: 'string' },
+      description: '調査の結果「問題なし」と確認できた設計判断',
+    },
+  },
+}
+
+const VERDICTS = {
+  type: 'object',
+  required: ['verdicts'],
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'isReal', 'reasoning'],
+        properties: {
+          title: { type: 'string', description: '検証対象の指摘 title をそのまま返す' },
+          isReal: { type: 'boolean', description: '実在する問題なら true。判断できなければ true（安全側）' },
+          reasoning: { type: 'string' },
+          correction: { type: 'string', description: '指摘が誤り・誇張の場合の正しい事実' },
+        },
+      },
+    },
+  },
+}
+
+const input = typeof args === 'string' ? JSON.parse(args) : args
+if (!input || !Array.isArray(input.dimensions) || (!input.context && !input.contextPath)) {
+  throw new Error('args には { context | contextPath, dimensions: [{key, prompt}] } を渡してください')
+}
+const dims = input.dimensions
+const routing = Object.assign(
+  {
+    reviewModel: 'sonnet',
+    verifyModel: 'sonnet',
+    reviewEffort: 'medium',
+    verifyEffort: 'medium',
+    verifyMinBudget: 30000, // budget 指定時、残りがこれ未満なら verify を省略
+    verifyCodexFindings: false, // true: Codex 由来の critical/major も Claude verify で二重検証
+  },
+  input.routing || {}
+)
+
+// コンテキストはファイル参照を優先（各エージェントのプロンプトを短く保つ）
+const contextBlock = input.contextPath
+  ? `設計コンテキストはファイル ${input.contextPath} に置いてある。最初に Read ツールで全文を読んでから作業すること。`
+  : input.context
+
+// Claude レビュアーの依頼文（従来の依頼文を一字一句変えず関数化したもの）
+const claudeReviewPrompt = (d) =>
+  [
+    'あなたは設計レビュアーです。以下のレンズの観点でのみレビューしてください（他レンズの領域には踏み込まない）。',
+    '',
+    '## レンズ',
+    d.prompt,
+    '',
+    '## レビュー対象の設計コンテキスト',
+    contextBlock,
+    '',
+    '## 進め方',
+    '- 事実確認が必要な外部仕様（ライブラリ API・ブラウザ挙動など）は、推測せず Web で一次情報を調査する（WebSearch / WebFetch が未ロードなら ToolSearch でロードして使う）',
+    '- リポジトリの実態確認が必要なら実ファイルを読む。ただし調査は指摘の裏取りに必要な範囲に絞り、網羅的な読み歩きはしない',
+    '- severity 基準: critical = このままだと設計が動かない/壊れる、major = 高確率で問題化する、minor = 改善余地、info = 補足',
+    '- 指摘には必ず evidence（URL かファイルパス）を付ける',
+    '- 「問題なし」と確認できた設計判断は okPoints に列挙する',
+    '- 日本語で書く',
+  ].join('\n')
+
+// Codex レビュアーの依頼文: 設計評価はエージェント自身が行わず、Codex CLI（別ベンダー）に実行させて
+// 結果を FINDINGS に正規化する係。実行方法は codex-discussion skill に厳密に従う
+const codexReviewPrompt = (d) =>
+  [
+    'あなたは Codex CLI の実行係です。設計レビューの中身はあなた自身では行わず、必ず Codex（別ベンダーの独立レビュアー）に実行させ、その結果を回収・正規化してください。',
+    '',
+    '## 手順',
+    '1. まず /Users/naganoma/Projects/Mabatalk/.claude/skills/codex-discussion/SKILL.md を Read し、そこに書かれた実行コマンド形・運用ルール（--sandbox read-only 必須、-o で結果回収、Bash timeout 600000 など）に厳密に従う',
+    '2. 下記レンズの観点でのレビュー依頼文を SKILL.md の「依頼文の型」に沿って組み立て、codex exec を実行する',
+    '3. 回収した出力を FINDINGS スキーマ（findings + okPoints）に正規化して返す。Codex が言っていない指摘を足さない・severity を付け直さない（欠損フィールドの補完のみ可）',
+    '',
+    '## レンズ（Codex への依頼観点）',
+    d.prompt,
+    '',
+    '## レビュー対象',
+    input.contextPath
+      ? `Codex への依頼文には「設計コンテキストはファイル ${input.contextPath} にあるので読むこと」と指示する（全文をプロンプトに貼らない）`
+      : ['contextPath がないため、以下の設計コンテキスト全文を Codex への依頼文の末尾に貼ること:', '', input.context].join('\n'),
+    '',
+    '## 失敗時',
+    'codex の exit code が非 0、または出力ファイルが空・存在しない場合は、findings: [] とし、okPoints に "codex 実行失敗:<理由>" を 1 件だけ入れて返す。あなた自身がレビューして findings を埋めることは絶対にしない。',
+  ].join('\n')
+
+// レンズの engine に応じてレビュアーを切り替える（engine 未指定 = 従来どおり Claude レビュー）
+const reviewAgent = (d) =>
+  agent(d.engine === 'codex' ? codexReviewPrompt(d) : claudeReviewPrompt(d), {
+    label: d.engine === 'codex' ? `review:codex:${d.key}` : `review:${d.key}`,
+    phase: 'Review',
+    schema: FINDINGS,
+    model: routing.reviewModel,
+    effort: routing.reviewEffort,
+  })
+
+phase('Review')
+log(`${dims.length} レンズで並列レビュー開始（review=${routing.reviewModel}/${routing.reviewEffort}, verify=${routing.verifyModel}/${routing.verifyEffort}）`)
+
+const results = await pipeline(
+  dims,
+  (d) => reviewAgent(d),
+  (r, d) => {
+    if (!r) return null
+    const toVerify = r.findings.filter((f) => f.severity === 'critical' || f.severity === 'major')
+    const rest = r.findings.filter((f) => f.severity !== 'critical' && f.severity !== 'major')
+    const base = { lens: d.key, okPoints: r.okPoints || [] }
+
+    if (toVerify.length === 0) {
+      return { ...base, findings: rest.map((f) => ({ ...f, lens: d.key })) }
+    }
+    // Codex 由来レンズ: Codex 自身が evidence 提示済みのため、既定では Claude verify による
+    // 二重検証を行わない（routing.verifyCodexFindings: true のときのみ従来どおり検証に回す）。
+    // 注意: verdict は文字列でなくオブジェクトにする。下流の confirmed 集計が
+    // 「!f.verdict || f.verdict.isReal」で判定するため、文字列 "codex-native" を入れると
+    // isReal が undefined になり codex の major が黙って全滅する
+    if (d.engine === 'codex' && !routing.verifyCodexFindings) {
+      return {
+        ...base,
+        findings: [
+          ...toVerify.map((f) => ({
+            ...f,
+            lens: d.key,
+            verdict: {
+              title: f.title,
+              isReal: true,
+              reasoning: 'codex-native（Codex 自身が根拠提示済みのため二重検証を省略。routing.verifyCodexFindings: true で検証可能）',
+            },
+          })),
+          ...rest.map((f) => ({ ...f, lens: d.key })),
+        ],
+      }
+    }
+    // budget ガード: 残量僅少なら未検証のまま返す（黙って落とさず明示する）
+    if (budget.total && budget.remaining() < routing.verifyMinBudget) {
+      log(`budget 残 ${Math.round(budget.remaining() / 1000)}k < ${Math.round(routing.verifyMinBudget / 1000)}k: ${d.key} の検証をスキップ（unverified 扱い）`)
+      return {
+        ...base,
+        findings: [...toVerify, ...rest].map((f) => ({ ...f, lens: d.key, verdict: null })),
+      }
+    }
+    // レンズ単位のバッチ検証: 1 エージェントが当該レンズの critical/major を全件まとめて反証する
+    return agent(
+      [
+        'あなたは懐疑的な検証者です。以下の設計レビュー指摘（複数件）を 1 件ずつ「反証」してみてください。',
+        '事実確認には Web 調査（WebSearch / WebFetch。未ロードなら ToolSearch でロード）やリポジトリの実ファイル読解を使い、推測で判定しないこと。',
+        '',
+        '## 対象設計コンテキスト',
+        contextBlock,
+        '',
+        '## 検証対象の指摘（JSON）',
+        JSON.stringify(toVerify.map(({ title, detail, evidence }) => ({ title, detail, evidence })), null, 2),
+        '',
+        '各指摘について: 実在する問題なら isReal: true。誤り・誇張なら isReal: false とし correction に正しい事実を書く。判断できない場合は isReal: true（安全側）。title は入力のものをそのまま返す。日本語で。',
+      ].join('\n'),
+      {
+        label: `verify:${d.key}`,
+        phase: 'Verify',
+        schema: VERDICTS,
+        model: routing.verifyModel,
+        effort: routing.verifyEffort,
+      }
+    ).then((v) => {
+      const byTitle = new Map((v?.verdicts || []).map((x) => [x.title, x]))
+      return {
+        ...base,
+        findings: [
+          ...toVerify.map((f) => ({ ...f, lens: d.key, verdict: byTitle.get(f.title) || null })),
+          ...rest.map((f) => ({ ...f, lens: d.key })),
+        ],
+      }
+    })
+  }
+)
+
+const all = results.filter(Boolean)
+const allFindings = all.flatMap((r) => r.findings)
+const confirmed = allFindings.filter((f) => !f.verdict || f.verdict.isReal)
+const rejected = allFindings.filter((f) => f.verdict && !f.verdict.isReal)
+const unverified = confirmed.filter((f) => (f.severity === 'critical' || f.severity === 'major') && !f.verdict)
+log(`確定 ${confirmed.length} 件（うち未検証 ${unverified.length} 件）/ 反証棄却 ${rejected.length} 件 / 完了レンズ ${all.length}/${dims.length}`)
+return {
+  confirmed,
+  rejected,
+  okPoints: all.flatMap((r) => r.okPoints),
+  completedLenses: all.map((r) => r.lens),
+  unverifiedCount: unverified.length,
+}

--- a/.claude/workflows/review-loop.js
+++ b/.claude/workflows/review-loop.js
@@ -1,0 +1,325 @@
+// review-loop — レビュー→修正→再レビューの収束ループ（design-review を部品として呼ぶ制御層）
+//
+// 役割分担:
+//   - design-review.js = 「1回のレビュー」という部品。本ファイルからは一切変更しない
+//   - 本ファイル        = 回す制御。停止判断・回数・履歴・トークン記録はすべてこのコードが持ち、
+//                          LLM の主観（「もう十分」）では止めない
+//
+// 停止条件（コード側で判定。優先順に）:
+//   1. critical/major が 0 件         → 収束として終了
+//   2. 今周の指摘がすべて既出         → 堂々巡りとして終了（seen には棄却済み指摘も含める。
+//                                        含めないと、却下された指摘が毎周復活して永遠に収束しない）
+//   3. round >= maxRounds             → 終了（未解消 major が残っていれば未完了フラグ）
+//   4. budget 残量 < loopMinBudget    → 未完了フラグを付けて終了
+//   5. Claude トークン累計 > tokenBudgetPerRun → 未完了フラグを付けて強制終了（maxRounds とは別の歯止め）
+//
+// 安全ゲート:
+//   - 修正は必ず使い捨てブランチ上のみ。main には触らない・push しない・自動マージしない
+//   - コミットは「テストが通った周」だけ、そのペースで 1 コミット。対象はその周の変更ファイルのみ
+//     （git add -A 禁止 = 無関係な未コミット変更を巻き込まない）
+//   - テスト失敗時はその周の変更ファイルだけを checkout -- で戻す（git reset --hard 禁止）
+//   - マージ可否の判断は人間。最終報告で必ず止まる
+//
+// args:
+//   contextPath       : 設計コンテキストのファイルパス（design-review にそのまま渡す）
+//   dimensions        : [{key, prompt, engine?}] レビューレンズ（design-review にそのまま渡す）
+//   routing?          : design-review の routing。★素通しし、ループ側でモデルを差し替えない。
+//                       追加で fixModel（既定 'sonnet'。込み入った修正のときだけ 'opus' に上げる）を読む
+//   maxRounds?        : 既定 3
+//   testCommand       : 例 "bundle exec rspec" / "npm test"（必須）
+//   tokenBudgetPerRun?: このループ実行全体で許す Claude トークン累計の上限（省略可）
+//   loopMinBudget?    : budget（+500k 指定等）使用時の残量下限。既定 60000
+//   timestamp?        : ブランチ名に使う（ワークフロー内では Date.now() が使えないため外から渡す）
+//
+// トークン記録: Claude 分は budget.spent() の差分で毎周実測する。Codex レンズの消費は
+// OpenAI 側で発生するため計測できない — 「実行した回数」だけを分けて記録する。
+
+export const meta = {
+  name: 'review-loop',
+  description: 'design-review を部品として呼び、レビュー→修正→テスト→再レビューを停止条件まで回す制御ループ',
+  whenToUse: '設計/コードレビューの指摘を修正まで自動で収束させたいとき。args に { contextPath, dimensions, testCommand, maxRounds?, routing?, timestamp? } を渡す。マージは常に人間が判断する',
+}
+
+const FIX_RESULT = {
+  type: 'object',
+  required: ['applied', 'changedFiles', 'changedFunctions', 'summary'],
+  properties: {
+    applied: { type: 'boolean', description: '1 件以上の修正を適用できたら true' },
+    baseSha: { type: 'string', description: 'ブランチ作成時に記録した分岐元コミット SHA（ブランチを新規作成した周のみ）' },
+    changedFiles: { type: 'array', items: { type: 'string' }, description: '変更したファイルのリポジトリ相対パス' },
+    changedFunctions: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['file', 'name'],
+        properties: {
+          file: { type: 'string' },
+          name: { type: 'string', description: '変更した関数/メソッド名' },
+          directCallers: { type: 'array', items: { type: 'string' }, description: 'この関数を直接呼び出している箇所（file:関数名 形式）' },
+        },
+      },
+    },
+    summary: { type: 'string', description: '何をどう直したかの要約' },
+    skipped: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'reason'],
+        properties: { title: { type: 'string' }, reason: { type: 'string' } },
+      },
+      description: '対応しなかった指摘とその理由',
+    },
+  },
+}
+
+const TEST_RESULT = {
+  type: 'object',
+  required: ['passed', 'committed'],
+  properties: {
+    passed: { type: 'boolean', description: 'testCommand が exit 0 なら true' },
+    committed: { type: 'boolean', description: 'この周の変更をコミットしたら true' },
+    commitSha: { type: 'string' },
+    reverted: { type: 'boolean', description: 'テスト失敗により変更を戻したら true' },
+    outputTail: { type: 'string', description: 'テスト出力の末尾（失敗時は失敗箇所が分かる部分）' },
+  },
+}
+
+// ---- 入力の検証と既定値 ----------------------------------------------------
+
+const input = typeof args === 'string' ? JSON.parse(args) : args
+if (!input || !input.contextPath || !Array.isArray(input.dimensions) || !input.testCommand) {
+  throw new Error('args には { contextPath, dimensions: [{key, prompt}], testCommand } が必須です')
+}
+const maxRounds = input.maxRounds || 3
+const tokenBudgetPerRun = input.tokenBudgetPerRun || null
+const loopMinBudget = input.loopMinBudget || 60000
+const fixModel = (input.routing && input.routing.fixModel) || 'sonnet'
+const branch = `review-loop/${input.timestamp || 'run'}`
+const repo = '/Users/naganoma/Projects/Mabatalk'
+
+// ---- ループが保持する状態（すべてコード側） --------------------------------
+
+let round = 0
+const seen = new Set() // 既出指摘の識別キー（confirmed も rejected も入れる）
+const history = [] // 各周の記録
+const tokenLog = [] // 各周のトークン消費（Claude 実測 / Codex は回数のみ）
+let branchCreated = false
+let baseSha = null
+let stopReason = null
+let incomplete = false
+let lastScope = null // 次周の再レビュー範囲（変更関数＋直接の呼び出し元）
+let lastTest = null
+
+// 指摘の識別キー。LLM は周をまたぐと文言を揺らすため、空白と記号を潰した title で照合する。
+// 完全な同一判定は不可能（言い換えには弱い）が、判定を LLM の主観に返さないことを優先する
+const normKey = (f) =>
+  `${(f.title || '')}`.toLowerCase().replace(/[\s、。・:：()（）\[\]「」]/g, '')
+
+// 再レビュー範囲の限定文。「変更関数＋その直接の呼び出し元」以外は読ませない
+const scopeNote = (scope) =>
+  [
+    '【再レビュー範囲の限定・厳守】',
+    '今回のレビュー対象は、直前の修正で変更された以下の関数と、それらを直接呼び出している箇所のみ。',
+    '「ファイル全体」「周辺コード」と拡大解釈しない。以下に挙がっていないコードは読まない。',
+    JSON.stringify(scope, null, 2),
+    '',
+    '',
+  ].join('\n')
+
+// ---- メインループ ----------------------------------------------------------
+
+while (true) {
+  round += 1
+  phase(`Round ${round}: Review`)
+  const spentAtRoundStart = budget.spent()
+
+  // 1. design-review を部品として呼ぶ（routing は素通し。ループ側でモデルを差し替えない）
+  const dims = lastScope
+    ? input.dimensions.map((d) => ({ ...d, prompt: scopeNote(lastScope) + d.prompt }))
+    : input.dimensions
+  const review = await workflow('design-review', {
+    contextPath: input.contextPath,
+    dimensions: dims,
+    routing: input.routing,
+  })
+  const reviewTokens = budget.spent() - spentAtRoundStart
+
+  const confirmedAll = (review && review.confirmed) || []
+  const rejectedAll = (review && review.rejected) || []
+  const majors = confirmedAll.filter((f) => f.severity === 'critical' || f.severity === 'major')
+
+  // 新規性判定は seen 更新「前」に行う
+  const freshKeys = majors.map(normKey).filter((k) => !seen.has(k))
+  // ★confirmed だけでなく棄却分も seen に入れる（却下された指摘の毎周復活を防ぐ）
+  confirmedAll.forEach((f) => seen.add(normKey(f)))
+  rejectedAll.forEach((f) => seen.add(normKey(f)))
+
+  history.push({
+    round,
+    majorsCount: majors.length,
+    freshCount: freshKeys.length,
+    confirmed: confirmedAll.map((f) => ({ title: f.title, severity: f.severity, lens: f.lens })),
+    rejected: rejectedAll.map((f) => ({ title: f.title, lens: f.lens })),
+  })
+  log(`Round ${round}: critical/major ${majors.length} 件（うち新規 ${freshKeys.length} 件）`)
+
+  // 2. 停止条件（修正を「回す前に」コードで判定）
+  if (majors.length === 0) {
+    stopReason = `収束: Round ${round} で critical/major が 0 件`
+    tokenLog.push({ round, claudeTokens: reviewTokens, codexLensCount: dims.filter((d) => d.engine === 'codex').length })
+    break
+  }
+  if (freshKeys.length === 0) {
+    stopReason = `堂々巡り: Round ${round} の指摘 ${majors.length} 件はすべて既出（棄却済み含む）`
+    incomplete = true
+    tokenLog.push({ round, claudeTokens: reviewTokens, codexLensCount: dims.filter((d) => d.engine === 'codex').length })
+    break
+  }
+  if (round >= maxRounds) {
+    stopReason = `maxRounds (${maxRounds}) 到達。未解消の critical/major が ${majors.length} 件残っている`
+    incomplete = true
+    tokenLog.push({ round, claudeTokens: reviewTokens, codexLensCount: dims.filter((d) => d.engine === 'codex').length })
+    break
+  }
+  if (budget.total && budget.remaining() < loopMinBudget) {
+    stopReason = `budget 残量不足: 残 ${Math.round(budget.remaining() / 1000)}k < ${Math.round(loopMinBudget / 1000)}k`
+    incomplete = true
+    tokenLog.push({ round, claudeTokens: reviewTokens, codexLensCount: dims.filter((d) => d.engine === 'codex').length })
+    break
+  }
+  const claudeTotalSoFar = tokenLog.reduce((s, t) => s + t.claudeTokens, 0) + reviewTokens
+  if (tokenBudgetPerRun && claudeTotalSoFar > tokenBudgetPerRun) {
+    stopReason = `tokenBudgetPerRun 超過: 累計 ${Math.round(claudeTotalSoFar / 1000)}k > ${Math.round(tokenBudgetPerRun / 1000)}k`
+    incomplete = true
+    tokenLog.push({ round, claudeTokens: reviewTokens, codexLensCount: dims.filter((d) => d.engine === 'codex').length })
+    break
+  }
+
+  // 3. 修正の適用（使い捨てブランチ上のみ・confirmed の critical/major に限定）
+  phase(`Round ${round}: Fix`)
+  const fix = await agent(
+    [
+      'あなたは修正担当です。以下のレビュー指摘（critical/major のみ）をリポジトリに適用してください。',
+      '',
+      '## ブランチ規律（厳守）',
+      branchCreated
+        ? `- 既に作業ブランチ ${branch} があるので \`git switch ${branch}\` で移ってから作業する`
+        : `- 最初に \`git rev-parse HEAD\` の結果を baseSha として記録し、\`git switch -c ${branch}\` で使い捨てブランチを作ってから作業する`,
+      '- main ブランチには絶対に触らない。push しない。コミットもしない（コミットはテスト担当が行う）',
+      '- 修正対象は下記の指摘のみ。minor/info の対応や「ついで」のリファクタは禁止',
+      '',
+      '## 修正する指摘（JSON）',
+      JSON.stringify(majors.map(({ title, severity, detail, recommendation, evidence }) => ({ title, severity, detail, recommendation, evidence })), null, 2),
+      '',
+      `## 参考: 設計コンテキストは ${input.contextPath} にある（必要なら Read する）`,
+      '',
+      '## 返すもの',
+      '- changedFiles: 変更したファイルのリポジトリ相対パス',
+      '- changedFunctions: 変更した関数と、それを直接呼び出している箇所（grep で調べて directCallers に列挙）',
+      '- 対応できない指摘は無理に直さず skipped に理由付きで返す',
+    ].join('\n'),
+    { label: `fix:round${round}`, phase: `Round ${round}: Fix`, schema: FIX_RESULT, model: fixModel }
+  )
+  if (fix && fix.baseSha && !baseSha) baseSha = fix.baseSha
+  if (fix && fix.applied) branchCreated = true
+
+  if (!fix || !fix.applied || fix.changedFiles.length === 0) {
+    stopReason = `Round ${round}: 修正エージェントが変更を適用できなかった`
+    incomplete = true
+    tokenLog.push({ round, claudeTokens: budget.spent() - spentAtRoundStart, codexLensCount: dims.filter((d) => d.engine === 'codex').length })
+    break
+  }
+
+  // 4. テスト → 通れば 1 コミット / 落ちればその周の変更だけ revert
+  const test = await agent(
+    [
+      'あなたはテスト・コミット担当です。以下を厳密に実行してください。',
+      '',
+      `1. \`git switch ${branch}\` で作業ブランチにいることを確認する`,
+      `2. テストを実行する: \`${input.testCommand}\`（Bash の timeout は 600000 にする）`,
+      '3. exit 0（成功）の場合のみ、以下のファイル「だけ」を git add してコミットする。git add -A / git add . は禁止（無関係な未コミット変更を巻き込まないため）:',
+      JSON.stringify(fix.changedFiles, null, 2),
+      `   コミットメッセージ: "review-loop round ${round}: ${fix.summary.slice(0, 60)}"`,
+      '4. テストが失敗した場合はコミットせず、上記ファイル「だけ」を `git checkout -- <ファイル>` で元に戻す。`git reset --hard` は禁止',
+      '5. どちらの場合も push はしない。main には触らない',
+      '',
+      '結果を passed / committed / commitSha / reverted / outputTail（テスト出力の末尾）で返す。',
+    ].join('\n'),
+    { label: `test:round${round}`, phase: `Round ${round}: Fix`, schema: TEST_RESULT, model: 'sonnet', effort: 'low' }
+  )
+  lastTest = test
+  tokenLog.push({
+    round,
+    claudeTokens: budget.spent() - spentAtRoundStart,
+    codexLensCount: dims.filter((d) => d.engine === 'codex').length,
+  })
+
+  const roundRec = history[history.length - 1]
+  roundRec.fix = { summary: fix.summary, changedFiles: fix.changedFiles, skipped: fix.skipped || [] }
+  roundRec.test = test ? { passed: test.passed, committed: test.committed, reverted: !!test.reverted } : { passed: false, committed: false, error: 'テスト担当が結果を返さなかった' }
+
+  if (test && test.passed) {
+    // 次周の再レビューは「今周の変更関数＋直接の呼び出し元」に限定
+    lastScope = fix.changedFunctions
+    log(`Round ${round}: テスト通過・コミット済み。次周は変更 ${fix.changedFunctions.length} 関数に限定して再レビュー`)
+  } else {
+    // 失敗は history に残した。変更は revert 済みなので次周は同じコードを見る
+    // → 同じ指摘が出て「堂々巡り」条件で止まる（無限に修正リトライしない）
+    lastScope = null
+    log(`Round ${round}: テスト失敗のため revert。失敗を記録して停止条件の判断に進む`)
+  }
+}
+
+// ---- 最終集約・報告（司令塔 = opus）。マージ可否は人間が判断する -------------
+
+phase('Report')
+const claudeTotal = tokenLog.reduce((s, t) => s + t.claudeTokens, 0)
+const codexRuns = tokenLog.reduce((s, t) => s + t.codexLensCount, 0)
+
+const report = await agent(
+  [
+    'あなたはこのレビューループの司令塔です。以下の実行記録を、人間がブランチのマージ可否を判断できる形に集約・報告してください。',
+    '',
+    '## 実行記録（JSON）',
+    JSON.stringify(
+      {
+        stopReason,
+        incomplete,
+        rounds: round,
+        branch: branchCreated ? branch : null,
+        baseSha,
+        history,
+        tokenLog,
+        claudeTokensTotal: claudeTotal,
+        codexLensRuns: codexRuns,
+        lastTest,
+      },
+      null,
+      2
+    ),
+    '',
+    '## やること',
+    branchCreated
+      ? `1. \`git diff ${baseSha || 'HEAD'} ${branch} --stat\` と必要なら本文を確認し、全体の変更を要約する（リポジトリ: ${repo}）`
+      : '1. ブランチは作成されていない（修正前に停止）。その旨を明記する',
+    '2. 確定した指摘・棄却された指摘・各周のトークン消費（Claude は実測値、Codex は OpenAI 側のため実行回数のみ）・最終テスト結果を表で整理する',
+    '3. 未解消の指摘が残っていれば、マージ判断に必要な残リスクとして明示する',
+    '4. 絶対にしないこと: マージ・push・main への操作。報告のみ',
+    '',
+    '日本語で、結論（マージ推奨/非推奨/条件付き）を先頭に書くこと。',
+  ].join('\n'),
+  { label: 'report', phase: 'Report', model: 'opus' }
+)
+
+return {
+  stopReason,
+  incomplete,
+  rounds: round,
+  branch: branchCreated ? branch : null,
+  baseSha,
+  tokenLog,
+  claudeTokensTotal: claudeTotal,
+  codexLensRuns: codexRuns,
+  history,
+  report,
+}

--- a/.claude/workflows/review-loop.js
+++ b/.claude/workflows/review-loop.js
@@ -29,7 +29,10 @@
 //   testCommand       : 例 "bundle exec rspec" / "npm test"（必須）
 //   tokenBudgetPerRun?: このループ実行全体で許す Claude トークン累計の上限（省略可）
 //   loopMinBudget?    : budget（+500k 指定等）使用時の残量下限。既定 60000
-//   timestamp?        : ブランチ名に使う（ワークフロー内では Date.now() が使えないため外から渡す）
+//   timestamp         : ブランチ名の一意化に使う（必須。ワークフロー内では Date.now() が使えず
+//                       一意な名前を自力で作れないため外から渡す。固定名だと再実行で
+//                       git switch -c が衝突する）
+//   repo?             : リポジトリの絶対パス。省略時はカレントの git リポジトリを使う
 //
 // トークン記録: Claude 分は budget.spent() の差分で毎周実測する。Codex レンズの消費は
 // OpenAI 側で発生するため計測できない — 「実行した回数」だけを分けて記録する。
@@ -90,12 +93,16 @@ const input = typeof args === 'string' ? JSON.parse(args) : args
 if (!input || !input.contextPath || !Array.isArray(input.dimensions) || !input.testCommand) {
   throw new Error('args には { contextPath, dimensions: [{key, prompt}], testCommand } が必須です')
 }
+if (!input.timestamp) {
+  // 固定のブランチ名は再実行時に git switch -c が衝突する。Date.now() は使えないため呼び出し側で渡す
+  throw new Error('args.timestamp は必須です（ブランチ名 review-loop/<timestamp> の一意化に使う）')
+}
 const maxRounds = input.maxRounds || 3
 const tokenBudgetPerRun = input.tokenBudgetPerRun || null
 const loopMinBudget = input.loopMinBudget || 60000
 const fixModel = (input.routing && input.routing.fixModel) || 'sonnet'
-const branch = `review-loop/${input.timestamp || 'run'}`
-const repo = '/Users/naganoma/Projects/Mabatalk'
+const branch = `review-loop/${input.timestamp}`
+const repo = input.repo || null // 省略時はカレントの git リポジトリ（エージェントの作業ディレクトリ）
 
 // ---- ループが保持する状態（すべてコード側） --------------------------------
 
@@ -259,9 +266,14 @@ while (true) {
   roundRec.test = test ? { passed: test.passed, committed: test.committed, reverted: !!test.reverted } : { passed: false, committed: false, error: 'テスト担当が結果を返さなかった' }
 
   if (test && test.passed) {
-    // 次周の再レビューは「今周の変更関数＋直接の呼び出し元」に限定
-    lastScope = fix.changedFunctions
-    log(`Round ${round}: テスト通過・コミット済み。次周は変更 ${fix.changedFunctions.length} 関数に限定して再レビュー`)
+    // 次周の再レビューは「今周の変更関数＋直接の呼び出し元」に限定。
+    // ただし報告が空配列だと限定範囲が実質ゼロ（何も読まないレビュー）になるため全域に戻す
+    lastScope = fix.changedFunctions && fix.changedFunctions.length > 0 ? fix.changedFunctions : null
+    log(
+      lastScope
+        ? `Round ${round}: テスト通過・コミット済み。次周は変更 ${lastScope.length} 関数に限定して再レビュー`
+        : `Round ${round}: テスト通過・コミット済み。変更関数の報告が空のため次周は全域レビュー`
+    )
   } else {
     // 失敗は history に残した。変更は revert 済みなので次周は同じコードを見る
     // → 同じ指摘が出て「堂々巡り」条件で止まる（無限に修正リトライしない）
@@ -300,7 +312,7 @@ const report = await agent(
     '',
     '## やること',
     branchCreated
-      ? `1. \`git diff ${baseSha || 'HEAD'} ${branch} --stat\` と必要なら本文を確認し、全体の変更を要約する（リポジトリ: ${repo}）`
+      ? `1. \`git diff ${baseSha || 'HEAD'} ${branch} --stat\` と必要なら本文を確認し、全体の変更を要約する${repo ? `（リポジトリ: ${repo}）` : '（カレントの git リポジトリで実行。必要なら `git rev-parse --show-toplevel` で確認）'}`
       : '1. ブランチは作成されていない（修正前に停止）。その旨を明記する',
     '2. 確定した指摘・棄却された指摘・各周のトークン消費（Claude は実測値、Codex は OpenAI 側のため実行回数のみ）・最終テスト結果を表で整理する',
     '3. 未解消の指摘が残っていれば、マージ判断に必要な残リスクとして明示する',

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@
 backup.dump
 
 /coverage
+.claude/settings.local.json


### PR DESCRIPTION
## 概要

AI による設計レビューを再現可能な仕組みとしてリポジトリに整備する。アプリ本体のコードには一切触れていない（`.claude/` 配下 + `.gitignore` のみ）。

## 追加ファイル

| ファイル | 役割 |
|---|---|
| `.claude/workflows/design-review.js` | 「1回のレビュー」の部品。レンズ並列レビュー + critical/major のレンズ単位バッチ反証検証。`engine: 'codex'` レンズで Codex CLI による別ベンダー独立レビューにも対応 |
| `.claude/workflows/review-loop.js` | 回す制御。レビュー→修正→テスト→再レビューを停止条件（収束 / 堂々巡り / maxRounds / トークン残量）までコード側判定で回す。修正は使い捨てブランチ上のみ・マージ判断は常に人間 |
| `.claude/skills/codex-discussion/SKILL.md` | Codex CLI への第三者レビュー依頼手順（`--sandbox read-only` 固定・失敗時に Claude が代行レビューして埋めることを禁止） |

## 設計方針

- 部品（1回のレビュー）と制御（ループ）を別ファイルに分離。停止判断・回数・履歴はすべてコードが持ち、LLM の主観では止めない
- トークン抑制: レビュー/検証/修正は Sonnet 既定・最終集約のみ Opus、verify はレンズ単位バッチ、再レビューは変更関数+直接呼び出し元に限定、budget ガード付き
- 安全ゲート: main 直接操作・push・自動マージ禁止、コミットは列挙ファイルのみ（`git add -A` 禁止）、`git reset --hard` 禁止

## 動作確認

- 両ワークフローとも Workflow 実行文脈（async 関数内）相当で構文チェック済み
- design-review.js は v2 相当を実データ（まばたき POC 設計レビュー）で実行済み（Sonnet 2 エージェント・83k トークンで完走）
- review-loop.js と Codex レンズは未実行（初回実行は別途承認の上で行う）

## 補足

- `.claude/settings.local.json`（個人設定）を `.gitignore` に追加
- `config/routes.rb` の未コミット変更は blink POC（#254）の作業のため本 PR には含めていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 設計レビューを複数観点で並列実行し、重要度の高い指摘だけを追加検証できるようになりました。
  * 修正・テスト・再レビューを自動で繰り返す収束ループが追加され、改善作業を継続しやすくなりました。
* **ドキュメント**
  * 外部レビューを安全に依頼するための手順、入力形式、失敗時の扱いが整理されました。
* **設定**
  * ローカル専用の設定が共有管理に含まれないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->